### PR TITLE
feat: add NuGet package support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Test
         run: dotnet test --no-build --configuration Release --verbosity normal --logger "trx;LogFileName=test-results.trx"
 
+      - name: Pack (verify NuGet package)
+        run: dotnet pack src/MiniPdf/MiniPdf.csproj --no-build --configuration Release --output ./nupkg
+
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -1,0 +1,40 @@
+name: NuGet Publish
+
+on:
+  release:
+    types: [ published ]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Test
+        run: dotnet test --no-build --configuration Release --verbosity normal
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+
+      - name: Pack
+        run: dotnet pack src/MiniPdf/MiniPdf.csproj --no-build --configuration Release -p:PackageVersion=${{ steps.version.outputs.VERSION }} --output ./nupkg
+
+      - name: Push to NuGet.org
+        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ A minimal, zero-dependency .NET library for generating PDF documents from text a
 
 ## Getting Started
 
+### Install via NuGet
+
+```bash
+dotnet add package MiniPdf
+```
+
 ### Requirements
 
 - .NET 9.0 or later

--- a/src/MiniPdf/MiniPdf.csproj
+++ b/src/MiniPdf/MiniPdf.csproj
@@ -9,9 +9,18 @@
     <!-- NuGet Package Metadata -->
     <PackageId>MiniPdf</PackageId>
     <Version>0.1.0</Version>
+    <Authors>shps951023</Authors>
     <Description>A minimal, zero-dependency .NET library for generating PDF documents from text and Excel files.</Description>
-    <PackageTags>pdf;excel;xlsx;converter;text</PackageTags>
+    <PackageTags>pdf;excel;xlsx;converter;text;minipdf</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/shps951023/MiniPdf</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/shps951023/MiniPdf.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Add NuGet package publishing infrastructure for MiniPdf.

### Changes

- **MiniPdf.csproj**: Added complete NuGet metadata (Authors, RepositoryUrl, RepositoryType, PackageProjectUrl, PackageReadmeFile)
- **nuget-publish.yml**: New GitHub Actions workflow that automatically publishes to NuGet.org when a GitHub Release is created
- **ci.yml**: Added `dotnet pack` verification step so every CI build ensures the package can be packed successfully
- **README.md**: Added `dotnet add package MiniPdf` install instructions

### How to publish a new version

1. Update `<Version>` in `src/MiniPdf/MiniPdf.csproj`
2. Create a GitHub Release with a tag like `v0.2.0`
3. The `nuget-publish.yml` workflow will automatically pack and push to NuGet.org

### Required secret

- `NUGET_API_KEY` — NuGet.org API key with push permission for the `MiniPdf` package

Closes #5
