### PR TITLE
Add culture support for XLSX number formatting

### DIFF
--- a/src/MiniPdf/ExcelReader.cs
+++ b/src/MiniPdf/ExcelReader.cs
@@ -34,7 +34,7 @@ internal static class ExcelReader
     /// Reads all sheets from an Excel file and returns their data as a list of sheets,
     /// where each sheet is a list of rows, and each row is a list of cell values.
     /// </summary>
-    internal static List<ExcelSheet> ReadSheets(Stream stream)
+    internal static List<ExcelSheet> ReadSheets(Stream stream, System.Globalization.CultureInfo? culture = null)
     {
         var sheets = new List<ExcelSheet>();
 
@@ -79,7 +79,7 @@ internal static class ExcelReader
             if (entry == null) continue;
 
             var hyperlinks = ReadWorksheetHyperlinks(archive, entry.FullName);
-            var rows = ReadSheet(entry, sharedStrings, boldPrefixLengths, fontStyles, fillColors, borders, numberFormats, cellXfFontIndices, cellXfFillIndices, cellXfNumFmtIds, cellXfAlignments, cellXfVerticalAlignments, cellXfBorderIndices, cellXfWrapTexts, cellXfIndents, hyperlinks);
+            var rows = ReadSheet(entry, sharedStrings, boldPrefixLengths, fontStyles, fillColors, borders, numberFormats, cellXfFontIndices, cellXfFillIndices, cellXfNumFmtIds, cellXfAlignments, cellXfVerticalAlignments, cellXfBorderIndices, cellXfWrapTexts, cellXfIndents, hyperlinks, culture);
             var images = ReadSheetImages(archive, entry.FullName);
             var drawingShapes = ReadSheetShapes(archive, entry.FullName, themeColors);
             var (colWidths, defaultColWidth) = ReadColumnWidths(entry);
@@ -108,7 +108,7 @@ internal static class ExcelReader
             if (entry != null)
             {
                 var hyperlinks = ReadWorksheetHyperlinks(archive, entry.FullName);
-                var rows = ReadSheet(entry, sharedStrings, boldPrefixLengths, fontStyles, fillColors, borders, numberFormats, cellXfFontIndices, cellXfFillIndices, cellXfNumFmtIds, cellXfAlignments, cellXfVerticalAlignments, cellXfBorderIndices, cellXfWrapTexts, cellXfIndents, hyperlinks);
+                var rows = ReadSheet(entry, sharedStrings, boldPrefixLengths, fontStyles, fillColors, borders, numberFormats, cellXfFontIndices, cellXfFillIndices, cellXfNumFmtIds, cellXfAlignments, cellXfVerticalAlignments, cellXfBorderIndices, cellXfWrapTexts, cellXfIndents, hyperlinks, culture);
                 var images = ReadSheetImages(archive, entry.FullName);
                 var (colWidths, defaultColWidth) = ReadColumnWidths(entry);
                 var mergedCells = ReadMergedCells(entry);
@@ -1812,7 +1812,7 @@ internal static class ExcelReader
     private static List<List<ExcelCell>> ReadSheet(ZipArchiveEntry entry, List<string> sharedStrings, Dictionary<int, int> boldPrefixLengths,
         List<FontStyleInfo> fontStyles, List<PdfColor?> fillColors, List<CellBorderInfo?> borders, Dictionary<int, string> numberFormats,
         List<int> cellXfFontIndices, List<int> cellXfFillIndices, List<int> cellXfNumFmtIds, List<string> cellXfAlignments, List<string> cellXfVerticalAlignments, List<int> cellXfBorderIndices, List<bool> cellXfWrapTexts, List<int> cellXfIndents,
-        Dictionary<string, string>? hyperlinks = null)
+        Dictionary<string, string>? hyperlinks = null, System.Globalization.CultureInfo? culture = null)
     {
         var rows = new List<List<ExcelCell>>();
 
@@ -2021,7 +2021,7 @@ internal static class ExcelReader
                             double.TryParse(text, System.Globalization.NumberStyles.Any,
                                 System.Globalization.CultureInfo.InvariantCulture, out var numVal))
                         {
-                            text = FormatNumber(numVal, numFmtId, numberFormats, out var fmtColor, out acctPrefix);
+                            text = FormatNumber(numVal, numFmtId, numberFormats, culture, out var fmtColor, out acctPrefix);
                             // Number format color overrides font color (e.g., [Red] for negatives)
                             if (fmtColor != null)
                                 color = fmtColor;
@@ -2507,11 +2507,11 @@ internal static class ExcelReader
     /// Formats a numeric value according to its Excel number format.
     /// Handles built-in formats and common custom patterns.
     /// </summary>
-    private static string FormatNumber(double value, int numFmtId, Dictionary<int, string> customFormats, out PdfColor? formatColor, out string? accountingPrefix)
+    private static string FormatNumber(double value, int numFmtId, Dictionary<int, string> customFormats, System.Globalization.CultureInfo? culture, out PdfColor? formatColor, out string? accountingPrefix)
     {
         formatColor = null;
         accountingPrefix = null;
-        var ci = System.Globalization.CultureInfo.InvariantCulture;
+        var ci = culture ?? System.Globalization.CultureInfo.InvariantCulture;
 
         // Check custom format first
         if (numFmtId > 0 && customFormats.TryGetValue(numFmtId, out var formatCode))

--- a/src/MiniPdf/ExcelReader.cs
+++ b/src/MiniPdf/ExcelReader.cs
@@ -2522,7 +2522,7 @@ internal static class ExcelReader
         // Built-in number formats
         return numFmtId switch
         {
-            0 => FormatGeneral(value),          // General
+            0 => FormatGeneral(value, ci),          // General
             1 => value.ToString("F0", ci),      // 0
             2 => value.ToString("F2", ci),      // 0.00
             3 => value.ToString("#,##0", ci),   // #,##0
@@ -2531,21 +2531,21 @@ internal static class ExcelReader
             10 => (value * 100).ToString("F2", ci) + "%", // 0.00%
             11 => value.ToString("0.00E+00", ci),         // 0.00E+00
             // Date formats (14-22): Excel stores dates as serial numbers
-            14 => FormatExcelDate(value, "M/d/yyyy"),
-            15 => FormatExcelDate(value, "d-MMM-yy"),
-            16 => FormatExcelDate(value, "d-MMM"),
-            17 => FormatExcelDate(value, "MMM-yy"),
-            18 => FormatExcelDate(value, "h:mm tt"),
-            19 => FormatExcelDate(value, "h:mm:ss tt"),
-            20 => FormatExcelDate(value, "H:mm"),
-            21 => FormatExcelDate(value, "H:mm:ss"),
-            22 => FormatExcelDate(value, "M/d/yyyy H:mm"),
+            14 => FormatExcelDate(value, "M/d/yyyy", ci),
+            15 => FormatExcelDate(value, "d-MMM-yy", ci),
+            16 => FormatExcelDate(value, "d-MMM", ci),
+            17 => FormatExcelDate(value, "MMM-yy", ci),
+            18 => FormatExcelDate(value, "h:mm tt", ci),
+            19 => FormatExcelDate(value, "h:mm:ss tt", ci),
+            20 => FormatExcelDate(value, "H:mm", ci),
+            21 => FormatExcelDate(value, "H:mm:ss", ci),
+            22 => FormatExcelDate(value, "M/d/yyyy H:mm", ci),
             // More number formats
             37 => value.ToString("#,##0", ci),
             38 => value.ToString("#,##0", ci),
             39 => value.ToString("#,##0.00", ci),
             40 => value.ToString("#,##0.00", ci),
-            _ => FormatGeneral(value)
+            _ => FormatGeneral(value, ci)
         };
     }
 
@@ -2805,9 +2805,9 @@ internal static class ExcelReader
     /// LibreOffice's General format adapts precision to fit approximately 10 characters,
     /// switching to scientific notation for very large/small values.
     /// </summary>
-    private static string FormatGeneral(double value)
+    private static string FormatGeneral(double value, IFormatProvider? provider = null)
     {
-        var ci = System.Globalization.CultureInfo.InvariantCulture;
+        var ci = provider ?? System.Globalization.CultureInfo.InvariantCulture;
         if (value == 0) return "0";
         var abs = Math.Abs(value);
 
@@ -2848,7 +2848,7 @@ internal static class ExcelReader
     /// Converts an Excel serial date number to a date string using the given format code.
     /// Excel epoch: Jan 1, 1900 = serial number 1.
     /// </summary>
-    private static string FormatExcelDate(double serialDate, string formatCode = "yyyy-MM-dd")
+    private static string FormatExcelDate(double serialDate, string formatCode = "yyyy-MM-dd", IFormatProvider? provider = null)
     {
         try
         {
@@ -2866,11 +2866,11 @@ internal static class ExcelReader
             // Convert Excel format code to .NET format
             var dotNetFormat = ConvertExcelDateFormat(formatCode);
 
-            return dateTime.ToString(dotNetFormat, System.Globalization.CultureInfo.InvariantCulture);
+            return dateTime.ToString(dotNetFormat, provider ?? System.Globalization.CultureInfo.InvariantCulture);
         }
         catch
         {
-            return serialDate.ToString("G10", System.Globalization.CultureInfo.InvariantCulture);
+            return serialDate.ToString("G10", provider ?? System.Globalization.CultureInfo.InvariantCulture);
         }
     }
 

--- a/src/MiniPdf/ExcelToPdfConverter.cs
+++ b/src/MiniPdf/ExcelToPdfConverter.cs
@@ -81,6 +81,9 @@ internal static class ExcelToPdfConverter
 
         /// <summary>Target minimum number of worksheet rows per PDF page.</summary>
         internal int? RowsPerPage { get; set; }
+
+        /// <summary>Optional culture used to format numeric and date values. Null uses invariant culture.</summary>
+        internal System.Globalization.CultureInfo? Culture { get; set; }
     }
 
     /// <summary>
@@ -104,7 +107,7 @@ internal static class ExcelToPdfConverter
     internal static PdfDocument Convert(Stream excelStream, ConversionOptions? options = null)
     {
         options ??= new ConversionOptions();
-        var sheets = ExcelReader.ReadSheets(excelStream);
+        var sheets = ExcelReader.ReadSheets(excelStream, options.Culture);
         sheets = FilterSheets(sheets, options.Sheets, options.SheetIndexes);
         sheets = ApplyRenderLimits(sheets, options.MaxRows, options.MaxColumns);
         sheets = ApplyLayoutOptions(sheets, options);

--- a/src/MiniPdf/MiniPdf.cs
+++ b/src/MiniPdf/MiniPdf.cs
@@ -42,6 +42,9 @@ public sealed class MiniPdfConversionOptions
 
     /// <summary>Target minimum number of worksheet rows per PDF page. Applies by fitting the sheet height to a derived page count.</summary>
     public int? RowsPerPage { get; set; }
+
+    /// <summary>Optional culture used to format numeric and date values from Excel cells. Null uses the invariant culture (current behavior).</summary>
+    public System.Globalization.CultureInfo? Culture { get; set; }
 }
 
 /// <summary>
@@ -684,7 +687,8 @@ public static class MiniPdf
         if (options.MaxRows.HasValue || options.MaxColumns.HasValue ||
             options.Landscape.HasValue || options.FitToPage.HasValue ||
             options.FitToWidth.HasValue || options.FitToHeight.HasValue ||
-            options.PrintScale.HasValue || options.RowsPerPage.HasValue)
+            options.PrintScale.HasValue || options.RowsPerPage.HasValue ||
+            options.Culture != null)
             throw new NotSupportedException("Excel-specific conversion options are only supported for .xlsx files.");
     }
 
@@ -717,6 +721,7 @@ public static class MiniPdf
             FitToHeight = options.FitToHeight,
             PrintScale = options.PrintScale,
             RowsPerPage = options.RowsPerPage,
+            Culture = options.Culture,
         };
 
     private static PdfSaveOptions? CreatePdfSaveOptions(MiniPdfConversionOptions options)

--- a/tests/MiniPdf.Tests/ExcelToPdfConverterTests.cs
+++ b/tests/MiniPdf.Tests/ExcelToPdfConverterTests.cs
@@ -616,6 +616,190 @@ public class ExcelToPdfConverterTests
         public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
 
+    [Fact]
+    public void Convert_BuiltInNumFmtId4_WithEsArCulture()
+    {
+        using var excelStream = CreateExcelWithBuiltInNumberFormat(numFmtId: 4, values: new[] { 30596.37 });
+
+        var doc = ExcelToPdfConverter.Convert(excelStream, new ExcelToPdfConverter.ConversionOptions
+        {
+            Culture = System.Globalization.CultureInfo.GetCultureInfo("es-AR"),
+        });
+
+        Assert.Contains(doc.Pages.SelectMany(page => page.TextBlocks), block => block.Text == "30.596,37");
+    }
+
+    [Fact]
+    public void Convert_BuiltInNumFmtId4_WithEnUsCulture()
+    {
+        using var excelStream = CreateExcelWithBuiltInNumberFormat(numFmtId: 4, values: new[] { 30596.37 });
+
+        var doc = ExcelToPdfConverter.Convert(excelStream, new ExcelToPdfConverter.ConversionOptions
+        {
+            Culture = System.Globalization.CultureInfo.GetCultureInfo("en-US"),
+        });
+
+        Assert.Contains(doc.Pages.SelectMany(page => page.TextBlocks), block => block.Text == "30,596.37");
+    }
+
+    [Fact]
+    public void Convert_BuiltInNumFmtId4_LargeValueWithEsArCulture()
+    {
+        using var excelStream = CreateExcelWithBuiltInNumberFormat(numFmtId: 4, values: new[] { 1234567.89 });
+
+        var doc = ExcelToPdfConverter.Convert(excelStream, new ExcelToPdfConverter.ConversionOptions
+        {
+            Culture = System.Globalization.CultureInfo.GetCultureInfo("es-AR"),
+        });
+
+        Assert.Contains(doc.Pages.SelectMany(page => page.TextBlocks), block => block.Text == "1.234.567,89");
+    }
+
+    [Fact]
+    public void Convert_BuiltInNumFmtId4_NullCulturePreservesInvariantBehavior()
+    {
+        using var excelStream = CreateExcelWithBuiltInNumberFormat(numFmtId: 4, values: new[] { 30596.37 });
+
+        var doc = ExcelToPdfConverter.Convert(excelStream);
+
+        Assert.Contains(doc.Pages.SelectMany(page => page.TextBlocks), block => block.Text == "30,596.37");
+    }
+
+    [Fact]
+    public void Convert_BuiltInNumFmtId4_MultipleValuesWithEsArCulture()
+    {
+        using var excelStream = CreateExcelWithBuiltInNumberFormat(
+            numFmtId: 4,
+            values: new[] { 0, 1, 100, 1234.5, 30596.37, 1234567.89, -30596.37 });
+
+        var doc = ExcelToPdfConverter.Convert(excelStream, new ExcelToPdfConverter.ConversionOptions
+        {
+            Culture = System.Globalization.CultureInfo.GetCultureInfo("es-AR"),
+        });
+
+        var expected = new[]
+        {
+            "0,00",
+            "1,00",
+            "100,00",
+            "1.234,50",
+            "30.596,37",
+            "1.234.567,89",
+            "-30.596,37",
+        };
+
+        foreach (var text in expected)
+        {
+            Assert.Contains(doc.Pages.SelectMany(page => page.TextBlocks), block => block.Text == text);
+        }
+    }
+
+    [Fact]
+    public void ConvertToPdf_PublicApi_BuiltInNumFmtId4_HonorsCulture()
+    {
+        using var excelStream = CreateExcelWithBuiltInNumberFormat(numFmtId: 4, values: new[] { 30596.37 });
+
+        var bytes = MiniPdf.ConvertToPdf(excelStream, new MiniPdfConversionOptions
+        {
+            Culture = System.Globalization.CultureInfo.GetCultureInfo("es-AR"),
+        });
+        var content = Encoding.ASCII.GetString(bytes);
+
+        Assert.Contains("30.596,37", content);
+    }
+
+    /// <summary>
+    /// Creates a minimal .xlsx with a built-in number format (numFmtId only, no custom
+    /// &lt;numFmts&gt; entry) and a single column of numeric cells using that format. This
+    /// reproduces the real-world XLSX where cells carry only a built-in numFmtId.
+    /// </summary>
+    private static MemoryStream CreateExcelWithBuiltInNumberFormat(int numFmtId, params double[] values)
+    {
+        var ms = new MemoryStream();
+
+        using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            AddEntry(archive, "[Content_Types].xml",
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+                  <Default Extension="xml" ContentType="application/xml"/>
+                  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+                  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+                  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+                  <Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>
+                </Types>
+                """);
+
+            AddEntry(archive, "_rels/.rels",
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+                  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+                </Relationships>
+                """);
+
+            AddEntry(archive, "xl/_rels/workbook.xml.rels",
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+                  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+                  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+                </Relationships>
+                """);
+
+            AddEntry(archive, "xl/workbook.xml",
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+                          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+                  <sheets>
+                    <sheet name="Sheet1" sheetId="1" r:id="rId1"/>
+                  </sheets>
+                </workbook>
+                """);
+
+            // styles.xml with a built-in numFmtId and no custom <numFmts> section:
+            // the cell style references the built-in format directly.
+            AddEntry(archive, "xl/styles.xml",
+                $$"""
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+                  <fonts count="1">
+                    <font><sz val="11"/><name val="Calibri"/></font>
+                  </fonts>
+                  <fills count="1">
+                    <fill><patternFill patternType="none"/></fill>
+                  </fills>
+                  <borders count="1">
+                    <border><left/><right/><top/><bottom/><diagonal/></border>
+                  </borders>
+                  <cellXfs count="1">
+                    <xf numFmtId="{{numFmtId}}" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>
+                  </cellXfs>
+                </styleSheet>
+                """);
+
+            var sheetSb = new StringBuilder();
+            sheetSb.AppendLine("""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>""");
+            sheetSb.AppendLine("""<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">""");
+            sheetSb.AppendLine("<sheetData>");
+            for (var i = 0; i < values.Length; i++)
+            {
+                sheetSb.AppendLine($"  <row r=\"{i + 1}\">");
+                sheetSb.AppendLine($"    <c r=\"A{i + 1}\" s=\"0\"><v>{values[i].ToString(System.Globalization.CultureInfo.InvariantCulture)}</v></c>");
+                sheetSb.AppendLine("  </row>");
+            }
+            sheetSb.AppendLine("</sheetData>");
+            sheetSb.AppendLine("</worksheet>");
+
+            AddEntry(archive, "xl/worksheets/sheet1.xml", sheetSb.ToString());
+        }
+
+        ms.Position = 0;
+        return ms;
+    }
+
     /// <summary>
     /// Creates a minimal valid .xlsx file in memory with the given data.
     /// </summary>

--- a/tests/MiniPdf.Tests/ExcelToPdfConverterTests.cs
+++ b/tests/MiniPdf.Tests/ExcelToPdfConverterTests.cs
@@ -695,6 +695,78 @@ public class ExcelToPdfConverterTests
     }
 
     [Fact]
+    public void Convert_BuiltInGeneralFormat_WithEsArCulture()
+    {
+        using var excelStream = CreateExcelWithBuiltInNumberFormat(numFmtId: 0, values: new[] { 30596.37 });
+
+        var doc = ExcelToPdfConverter.Convert(excelStream, new ExcelToPdfConverter.ConversionOptions
+        {
+            Culture = System.Globalization.CultureInfo.GetCultureInfo("es-AR"),
+        });
+
+        Assert.Contains(doc.Pages.SelectMany(page => page.TextBlocks), block => block.Text == "30596,37");
+    }
+
+    [Fact]
+    public void Convert_BuiltInGeneralFormat_WithEnUsCulture()
+    {
+        using var excelStream = CreateExcelWithBuiltInNumberFormat(numFmtId: 0, values: new[] { 30596.37 });
+
+        var doc = ExcelToPdfConverter.Convert(excelStream, new ExcelToPdfConverter.ConversionOptions
+        {
+            Culture = System.Globalization.CultureInfo.GetCultureInfo("en-US"),
+        });
+
+        Assert.Contains(doc.Pages.SelectMany(page => page.TextBlocks), block => block.Text == "30596.37");
+    }
+
+    [Fact]
+    public void Convert_BuiltInGeneralFormat_NullCulturePreservesInvariantBehavior()
+    {
+        using var excelStream = CreateExcelWithBuiltInNumberFormat(numFmtId: 0, values: new[] { 30596.37 });
+
+        var doc = ExcelToPdfConverter.Convert(excelStream);
+
+        Assert.Contains(doc.Pages.SelectMany(page => page.TextBlocks), block => block.Text == "30596.37");
+    }
+
+    [Fact]
+    public void Convert_BuiltInDateFormat_WithEsArCulture()
+    {
+        using var excelStream = CreateExcelWithBuiltInNumberFormat(numFmtId: 15, values: new[] { 44927.0 });
+
+        var doc = ExcelToPdfConverter.Convert(excelStream, new ExcelToPdfConverter.ConversionOptions
+        {
+            Culture = System.Globalization.CultureInfo.GetCultureInfo("es-AR"),
+        });
+
+        Assert.Contains(doc.Pages.SelectMany(page => page.TextBlocks), block => block.Text == "1-ene-23");
+    }
+
+    [Fact]
+    public void Convert_BuiltInDateFormat_WithEnUsCulture()
+    {
+        using var excelStream = CreateExcelWithBuiltInNumberFormat(numFmtId: 15, values: new[] { 44927.0 });
+
+        var doc = ExcelToPdfConverter.Convert(excelStream, new ExcelToPdfConverter.ConversionOptions
+        {
+            Culture = System.Globalization.CultureInfo.GetCultureInfo("en-US"),
+        });
+
+        Assert.Contains(doc.Pages.SelectMany(page => page.TextBlocks), block => block.Text == "1-Jan-23");
+    }
+
+    [Fact]
+    public void Convert_BuiltInDateFormat_NullCulturePreservesInvariantBehavior()
+    {
+        using var excelStream = CreateExcelWithBuiltInNumberFormat(numFmtId: 15, values: new[] { 44927.0 });
+
+        var doc = ExcelToPdfConverter.Convert(excelStream);
+
+        Assert.Contains(doc.Pages.SelectMany(page => page.TextBlocks), block => block.Text == "1-Jan-23");
+    }
+
+    [Fact]
     public void ConvertToPdf_PublicApi_BuiltInNumFmtId4_HonorsCulture()
     {
         using var excelStream = CreateExcelWithBuiltInNumberFormat(numFmtId: 4, values: new[] { 30596.37 });


### PR DESCRIPTION
## Summary

Add optional `CultureInfo` support for localized numeric formatting when converting XLSX files to PDF.

## Problem

Excel can store numeric cells using built-in number formats such as `numFmtId=4` without storing an explicit localized format string.

MiniPdf was formatting these values using `InvariantCulture`, resulting in US-style separators such as:

`30,596.37`

even when the Excel document was intended to be displayed using Argentine formatting:

`30.596,37`

## Changes

- Add optional `CultureInfo? Culture` to `MiniPdfConversionOptions`.
- Propagate the culture through the XLSX conversion pipeline to `ExcelReader`.
- Use the provided culture when formatting built-in numeric formats.
- Preserve the existing `InvariantCulture` behavior when `Culture` is `null`.
- Keep XLSX XML numeric parsing invariant.
- Do not modify global `CurrentCulture` or `InvariantCulture`.
- No custom-format heuristics were introduced.

## Tests

Added coverage for the real XLSX structure using built-in `numFmtId=4` without a `<numFmts>` section.

Verified:

- `es-AR` → `30.596,37`
- `en-US` → `30,596.37`
- Large values → `1.234.567,89`
- Negative values → `-30.596,37`
- `Culture = null` preserves the existing behavior

All tests pass:

- `181` passed
- `0` failed
- `0` skipped

`dotnet build` also completes with 0 errors and 0 warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional culture setting for Excel-to-PDF conversion.
  * Numeric, general, and date values can now follow regional formatting conventions.
  * The setting is available through the public conversion options.

* **Bug Fixes**
  * Improved built-in Excel number and date formatting across different locales.
  * Existing invariant formatting is preserved when no culture is specified.

* **Tests**
  * Added coverage for regional numeric and date formatting, default behavior, and conversion options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->