### PR TITLE
Add community governance foundation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary
+
+Describe the problem and the intended behavior. Link the relevant issue or
+discussion when one exists.
+
+## Validation
+
+List the exact commands run and their results. Include focused visual benchmark
+scores or before-and-after images for rendering changes.
+
+## Checklist
+
+- [ ] The change is focused and does not include unrelated formatting or generated files.
+- [ ] New or changed behavior has automated test coverage where practical.
+- [ ] Relevant .NET and/or Rust checks pass.
+- [ ] Public API and compatibility effects are documented.
+- [ ] Security implications and untrusted-input behavior were considered.
+- [ ] I have the right to submit every added source file, fixture, font, image, and other asset under its stated license.
+- [ ] Third-party and generated material includes its source and license.
+- [ ] Test documents contain no confidential information or personal data.
+- [ ] User-facing documentation is updated, including translated README files when the English README changed.
+- [ ] Large benchmark outputs are attached or stored as CI artifacts unless they are required canonical evidence.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,66 @@
+# MiniPdf Code of Conduct
+
+## Our Commitment
+
+MiniPdf welcomes participation from anyone who contributes in good faith. We
+are committed to a respectful, harassment-free community regardless of age,
+body size, disability, ethnicity, sex characteristics, gender identity and
+expression, experience level, education, socioeconomic status, nationality,
+personal appearance, race, caste, religion, sexual identity and orientation,
+or technical preferences.
+
+## Expected Behavior
+
+- Be respectful, specific, and constructive.
+- Critique ideas and changes, not people.
+- Give others time to respond across time zones and language boundaries.
+- State assumptions and disclose relevant conflicts of interest.
+- Accept responsibility, apologize when appropriate, and repair harm.
+- Keep security reports and sensitive personal matters private.
+
+## Unacceptable Behavior
+
+- Harassment, threats, discrimination, or demeaning comments.
+- Sexualized language, imagery, or unwanted attention.
+- Trolling, sustained disruption, or deliberate intimidation.
+- Publishing another person's private information without permission.
+- Retaliation against someone who reports a concern in good faith.
+- Using project authority, employment, or organizational status to pressure
+  another participant.
+
+## Scope
+
+This policy applies in project repositories, discussions, issue trackers,
+review threads, events, and private communications related to project work. It
+also applies when someone publicly represents the project.
+
+## Reporting
+
+For an immediate safety concern, contact the relevant local authority or
+platform safety team first.
+
+For a project conduct concern, contact an active maintainer listed in
+`MAINTAINERS.md` through a private channel shown on their GitHub profile. If no
+private channel is available, open an issue requesting private contact without
+including names or incident details.
+
+Do not report a maintainer to that same person. When the current maintainer is
+involved, request an independent moderator through the MiniPdf GitHub
+organization. The project will document a dedicated independent reporting
+channel as the maintainer group grows.
+
+Reports will be handled as confidentially as reasonably possible. Information
+is shared only with people needed to assess and resolve the report. Knowingly
+false or retaliatory reports are themselves a violation, but an unproven good-
+faith report is not.
+
+## Enforcement
+
+Maintainers may remove content, issue a private or public warning, limit
+participation, temporarily suspend access, or permanently remove someone from
+project spaces. Responses should be proportionate to the conduct, its impact,
+and any pattern of behavior.
+
+Enforcement decisions involving a maintainer require review by an unconflicted
+maintainer or independent moderator. Public statements should protect reporter
+privacy while explaining actions needed for community safety.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,112 @@
 # Contributing to MiniPdf
 
-## Donate Compute with Any Coding Agent
+Thank you for helping MiniPdf. Contributions include code, documentation,
+tests, issue triage, design discussion, release verification, and user support.
+
+Please follow the `CODE_OF_CONDUCT.md`. Project decisions and the path to
+maintainership are documented in `GOVERNANCE.md`; current priorities are in
+`ROADMAP.md`.
+
+## Before You Start
+
+- Search existing issues and discussions before opening a new one.
+- Use an issue or discussion for a significant API, architecture, dependency,
+	compatibility, governance, or release-process change before implementation.
+- Do not submit confidential documents, personal data, proprietary fonts, or
+	test files that you do not have permission to redistribute.
+- Report suspected vulnerabilities through `SECURITY.md`, not a public issue.
+
+By submitting a contribution, you represent that you have the right to submit
+it under the repository's Apache License 2.0. Clearly identify third-party code,
+fixtures, images, fonts, or generated material and include their source and
+license. MiniPdf does not currently require a separate contributor license
+agreement.
+
+## Development Setup
+
+Clone your fork and create a focused branch. Keep unrelated formatting,
+generated artifacts, and benchmark refreshes out of the change.
+
+### .NET
+
+Install a supported .NET SDK, then run:
+
+```powershell
+dotnet restore
+dotnet build --configuration Release
+dotnet test tests/MiniPdf.Tests --configuration Release
+```
+
+### Rust
+
+Install the stable Rust toolchain, then run:
+
+```powershell
+Set-Location minipdf-rs
+cargo fmt --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+### Documentation
+
+Keep commands, APIs, benchmark results, and report links consistent. Changes to
+the English `README.md` must also be applied to the corresponding translated
+README files under `documents/`.
+
+## Making a Change
+
+1. Reproduce the behavior with the smallest useful test or fixture.
+2. Make one focused change at the owning implementation boundary.
+3. Add or update automated tests for behavior changes.
+4. Run the relevant .NET or Rust checks above.
+5. For rendering changes, run the narrowest applicable visual benchmark.
+6. Explain compatibility, security, provenance, and documentation effects in
+	 the pull request.
+
+Useful focused benchmark commands include:
+
+```powershell
+scripts/Run-Benchmark.ps1 -Filter "border"
+scripts/Run-Benchmark_docx.ps1 -Filter "heading"
+scripts/Run-Benchmark_issues.ps1 -Filter "sa8000"
+scripts/Run-Rust-Benchmark.ps1 -Filter "classic01" -MinimumScore 0.99
+```
+
+Generated PDFs, PNGs, heatmaps, and reports should only be committed when they
+are canonical project evidence requested by the relevant workflow. Otherwise,
+attach them to the pull request or retain them as CI artifacts.
+
+## Pull Requests
+
+Pull requests should be small enough to review and should include:
+
+- the problem and intended behavior;
+- linked issues or design discussions when applicable;
+- tests and exact validation commands;
+- before-and-after benchmark evidence for rendering changes;
+- public API or compatibility impact;
+- the source and license of new third-party material; and
+- documentation updates for user-visible behavior.
+
+At least one maintainer approval is currently required before merge. The
+project aims to provide an initial review within seven days, but complex visual
+rendering and security changes may take longer. Authors should respond to review
+questions and avoid force-pushing after review begins unless rebasing is needed.
+
+Maintainers may request that a large change be split, discussed publicly, or
+reworked to preserve compatibility and project scope. Reviews assess the change,
+not the contributor.
+
+## Earning More Responsibility
+
+Sustained contributions and sound judgment can lead to maintainer
+responsibility. Code volume is not the only form of merit: reviews,
+documentation, issue triage, release verification, security work, and community
+support all count. See `GOVERNANCE.md` for the selection process and
+`MAINTAINERS.md` for areas that need additional ownership.
+
+## Automated Rendering Improvement
 
 The automated rendering-improvement loop works with any coding agent that can
 edit repository files and run PowerShell, including GitHub Copilot, Claude Code,
@@ -49,7 +155,7 @@ visual regression gate. `Pr` generates benchmark evidence and either a GitHub
 CLI command or browser instructions. Committing, pushing, and opening the pull
 request still require explicit user approval.
 
-## Agent Shortcuts
+### Agent Shortcuts
 
 | Agent | Shortcut |
 |---|---|

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,131 @@
+# MiniPdf Governance
+
+MiniPdf is governed by its active contributors. The project aims to make
+decisions openly, recognize sustained merit, and avoid dependence on any one
+person or organization.
+
+MiniPdf is not an Apache Software Foundation project. This policy adopts useful
+open-source governance practices while the community evaluates its long-term
+governance options.
+
+## Principles
+
+- Project decisions serve users and the long-term health of the project.
+- Participants act as individuals. Employment or organizational affiliation
+  does not grant additional authority.
+- Technical and governance decisions are discussed in public and in writing.
+- Contributions of code, documentation, testing, issue triage, reviews,
+  security work, release verification, and community support all count as
+  merit.
+- Authority is earned through sustained, constructive participation and can be
+  shared with any contributor who demonstrates the required judgment.
+
+## Roles
+
+### Contributors
+
+Anyone who participates constructively is a contributor. Contributors may open
+issues and discussions, submit pull requests, review work, improve
+documentation, verify releases, and help other users.
+
+### Maintainers
+
+Maintainers are contributors trusted to merge changes and participate in
+project decisions. Maintainers are expected to:
+
+- review contributions fairly and promptly;
+- explain consequential decisions in public;
+- protect compatibility, security, licensing, and release quality;
+- disclose relevant conflicts of interest; and
+- help qualified contributors take on greater responsibility.
+
+The current maintainers and their areas of responsibility are listed in
+`MAINTAINERS.md`.
+
+### Release Managers
+
+A release manager prepares a release candidate and coordinates its review. The
+role is temporary for each release and does not grant unilateral authority to
+publish it. Release approval follows the process documented below.
+
+## Decision Making
+
+Routine, reversible changes use lazy consensus. A proposal may proceed after a
+reasonable review period when there is support and no unresolved objection from
+a maintainer. The expected review period is at least 72 hours for significant
+changes and may be shorter for routine pull requests.
+
+Significant decisions must begin as a public GitHub issue or discussion. These
+include:
+
+- changes to governance, licensing, project scope, or compatibility policy;
+- removal or substantial redesign of a public API;
+- adoption of a required runtime dependency;
+- changes to the release process; and
+- promotion or removal of a maintainer.
+
+The proposer should describe the problem, alternatives, compatibility impact,
+and a migration plan when applicable. Decisions reached in meetings or private
+messages must be summarized in the public thread before implementation.
+
+## Voting
+
+When discussion does not produce a clear consensus, a maintainer may call a
+vote in the relevant public issue or discussion. Votes remain open for at least
+72 hours and use these values:
+
+- `+1`: support
+- `0`: no position
+- `-1`: oppose, with an explanation and preferably an alternative
+
+Unless a stricter rule is documented, a vote passes with at least three
+maintainer votes, more `+1` than `-1`, and no unresolved technical veto on a
+code change. If the project has fewer than three active maintainers, all active
+maintainers must participate and the result must be unanimous. This fallback is
+temporary and should not be treated as evidence of a diverse community.
+
+Release candidates require at least three positive maintainer votes after each
+voter independently verifies the source archive, checks its provenance and
+licensing material, and builds and tests it. Until the project has three active
+maintainers, releases continue under the existing process and must explicitly
+record that governance limitation.
+
+## Becoming a Maintainer
+
+There is no fixed contribution count. A candidate should demonstrate sustained
+participation, sound technical or community judgment, constructive review, and
+an understanding of the project's security and licensing responsibilities.
+
+Any maintainer may nominate a contributor in a private discussion when personal
+information must be considered. The final invitation and its rationale are
+announced publicly after approval by consensus of the active maintainers. A
+candidate's employer, nationality, or use of a particular programming language
+must not affect the decision.
+
+## Inactive Maintainers
+
+A maintainer who has not participated for six months may move to emeritus status
+after a public check-in. Emeritus maintainers retain recognition and may return
+to active status by resuming sustained participation. Access may be removed
+immediately when necessary to protect the project or its users, followed by a
+documented maintainer review.
+
+## Conflicts of Interest
+
+Participants must disclose financial, employment, or personal interests that a
+reasonable observer could expect to affect a decision. A conflicted maintainer
+may provide relevant facts but should abstain from the final decision. The
+remaining maintainers decide whether recusal is necessary.
+
+## Private Matters
+
+Security reports, conduct reports, credentials, and sensitive personal matters
+must use the private channels documented in `SECURITY.md` and
+`CODE_OF_CONDUCT.md`. Technical outcomes should be summarized publicly once it
+is safe and appropriate to do so.
+
+## Changing This Policy
+
+Changes to this policy require a public proposal, at least seven days of
+discussion, and consensus of the active maintainers. The discussion must explain
+how the change improves openness, independence, or project sustainability.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,49 @@
+# MiniPdf Maintainers
+
+This file lists the people who currently have project-wide decision and merge
+responsibility. It is intentionally separate from the GitHub organization
+membership list.
+
+| Maintainer | Areas | Affiliation |
+|---|---|---|
+| [@shps951023](https://github.com/shps951023) | Project-wide, .NET, Rust, releases | Not declared |
+
+The project currently depends on one active maintainer. This is a known
+sustainability risk, not the desired long-term governance model.
+
+## Responsibilities
+
+Maintainers review contributions, participate in public decisions, protect the
+project's security and licensing, and help other contributors acquire the
+context needed to share these responsibilities.
+
+Area ownership is coordination responsibility, not exclusive authority. Any
+qualified contributor may review or contribute in any area.
+
+## Joining
+
+Maintainers are selected based on sustained, constructive participation and
+sound judgment across code, documentation, issue triage, reviews, security,
+release verification, or community support. The process is defined in
+`GOVERNANCE.md`.
+
+The project is actively seeking independent maintainers for these areas:
+
+- .NET document layout and PDF generation;
+- Rust XLSX and DOCX rendering;
+- security and dependency review;
+- test corpus and visual benchmark maintenance; and
+- release preparation and independent verification.
+
+## Affiliations
+
+Maintainers should update their affiliation when employment or another
+organizational relationship could reasonably be relevant to project decisions.
+An affiliation does not grant or reduce authority. Contributors participate as
+individuals.
+
+## Emeritus Status
+
+Inactive maintainers may move to emeritus status under `GOVERNANCE.md`.
+Emeritus maintainers remain credited but are not counted as active voters or
+reviewers.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ opens a PR without your approval.
 | [Rust XLSX benchmark](artifacts/rust-benchmark/classic/xlsx/report/comparison_report.md) | Rust spreadsheet visual comparison results |
 | [Rust DOCX benchmark](artifacts/rust-benchmark/classic/docx/report/comparison_report.md) | Rust document visual comparison results |
 | [Rust benchmark workflow](scripts/Run-Rust-Benchmark.ps1) | Generate fixture coverage and comparison reports |
+| [Community governance](GOVERNANCE.md) | Decisions, roles, voting, and maintainer selection |
+| [Roadmap](ROADMAP.md) | Project scope, implementation status, and current priorities |
+| [Security](SECURITY.md) | Private vulnerability reporting and supported versions |
+| [Contributing](CONTRIBUTING.md) | Development setup, tests, reviews, and provenance requirements |
 | [GitHub releases](https://github.com/mini-software/MiniPdf/releases) | Packages and standalone binaries |
 | [Issues](https://github.com/mini-software/MiniPdf/issues) | Bugs, compatibility reports, and feature requests |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,101 @@
+# MiniPdf Roadmap
+
+This roadmap describes current priorities, not a promise of delivery dates.
+Priorities are refined through public issues and discussions under
+`GOVERNANCE.md`.
+
+MiniPdf is not an Apache Software Foundation project. The project is adopting
+open, independent governance practices and may seek an Apache Incubator
+readiness review after demonstrating that those practices work in public.
+
+## Project Scope
+
+The core project provides embeddable, open-source Office-to-PDF conversion
+engines, public library APIs, command-line interfaces, and a shared conformance
+corpus. Conversion must not require Microsoft Office, LibreOffice, Adobe
+Acrobat, or COM automation at runtime.
+
+The GUI, web demo, hosted API, deployment examples, benchmarks, and coding-agent
+automation are convenience tooling. They may move to separate repositories when
+that improves ownership, release clarity, or repository size.
+
+MiniExcel is a separate project and is not part of MiniPdf governance or any
+future MiniPdf incubation proposal.
+
+## Implementation Status
+
+| Area | .NET | Rust |
+|---|---|---|
+| XLSX to PDF | Stable, with documented compatibility limits | Experimental |
+| DOCX to PDF | Stable, with documented compatibility limits | Experimental |
+| PPTX to PDF | Basic support | Unsupported |
+| Library API | Stable release line | Experimental pre-1.0 release line |
+| CLI | Supported | Experimental |
+
+Stable means the implementation is released and covered by the project's normal
+compatibility process. It does not mean complete Microsoft Office layout
+fidelity. Experimental areas may change incompatibly and must identify known
+gaps in their release notes.
+
+## Near-Term Priorities
+
+### Open Governance and Community
+
+- Apply the public decision process to significant technical and governance
+  changes.
+- Expand the active maintainer group to at least three legally independent
+  participants through demonstrated merit, not honorary appointments.
+- Enable contributors other than the founder to lead triage, reviews, design
+  discussions, and release preparation.
+- Publish community-health evidence without counting bots or mechanical
+  artifact refreshes as independent participation.
+
+### Security and Provenance
+
+- Inventory the origin and licensing of source files, dependencies, fonts,
+  images, Office fixtures, PDFs, and generated artifacts.
+- Add malformed ZIP/XML, resource-limit, path-handling, concurrency, and fuzz
+  coverage for untrusted inputs.
+- Generate dependency license reports and software bills of materials for
+  release candidates.
+
+### Reproducible Releases
+
+- Produce source-first release candidates from immutable commits.
+- Add checksums, signatures, and source-to-binary manifests.
+- Require independent build and test verification before publication.
+- Rehearse at least two public, multi-person releases before requesting an
+  external governance-readiness review.
+
+### Maintainable Implementations
+
+- Run .NET and Rust validation on every relevant pull request.
+- Maintain a versioned format and feature support matrix.
+- Use shared conformance fixtures where behavior should match while allowing
+  implementation-specific architecture.
+- Move large generated benchmark outputs out of the main source history while
+  retaining compact, reviewable summaries.
+
+## Non-Goals
+
+- Claiming complete Microsoft Office rendering compatibility.
+- Requiring the .NET and Rust implementations to share an architecture.
+- Promoting experimental features to stable to meet a date.
+- Increasing contributor counts through nominal or inactive roles.
+- Treating stars, downloads, or generated commits as substitutes for a
+  sustainable contributor community.
+
+## Readiness Review Gate
+
+The project should postpone an Apache Incubator proposal until it can show:
+
+- at least three active and legally independent maintainers with real decision
+  and review responsibility;
+- sustained external contribution and independent review during the previous
+  90 days;
+- two reproducible source-first release rehearsals, each independently verified
+  by three participants;
+- public records for consequential decisions and maintainer selection;
+- no unresolved high-risk provenance or licensing findings; and
+- a clear willingness to transfer required code and trademark rights if an
+  incubation proposal is accepted.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,54 @@
+# Security Policy
+
+MiniPdf processes untrusted ZIP, XML, image, font, and document content. Security
+reports are treated as a high priority even when the affected behavior is not
+yet covered by an automated test.
+
+## Supported Versions
+
+Security fixes are provided for the latest published .NET release and the
+latest published Rust release. Older versions may receive a fix when the impact
+and backport risk justify it, but this is not guaranteed.
+
+## Reporting a Vulnerability
+
+Do not open a public issue for a vulnerability that has not been coordinated.
+Use GitHub's private vulnerability reporting form:
+
+https://github.com/mini-software/MiniPdf/security/advisories/new
+
+Include, when possible:
+
+- the affected package, version, platform, and document format;
+- a minimal reproducer or proof of concept;
+- the expected impact and required attacker capabilities;
+- whether the issue is already public; and
+- any suggested mitigation.
+
+Do not include confidential production documents or personal data. Create a
+small synthetic reproducer whenever possible.
+
+If private vulnerability reporting is unavailable, open a public issue asking a
+maintainer to establish private contact. Do not include vulnerability details in
+that issue.
+
+## Response Process
+
+The project aims to acknowledge a report within seven days. A maintainer will
+coordinate validation, affected-version analysis, a fix, release timing, and
+credit with the reporter. Complex reports may take longer, but the reporter
+should receive progress updates.
+
+Security fixes should include a regression test when it can be added without
+revealing an unpatched vulnerability. Advisories are published after a fix is
+available or when disclosure is otherwise necessary to protect users.
+
+## Scope
+
+Examples of in-scope reports include arbitrary code execution, path traversal,
+ZIP bombs or uncontrolled resource consumption, unsafe XML processing,
+malformed-input crashes that enable denial of service, and disclosure of input
+document content.
+
+Reports that only compare rendering fidelity, without a security impact, should
+use the conversion-quality issue form instead.

--- a/documents/README.fr.md
+++ b/documents/README.fr.md
@@ -110,6 +110,10 @@ Les deux parcours nécessitent Git, Python 3.10+ et LibreOffice. .NET nécessite
 | [Benchmark XLSX Rust](../artifacts/rust-benchmark/classic/xlsx/report/comparison_report.md) | Résultats de comparaison visuelle Rust des feuilles de calcul |
 | [Benchmark DOCX Rust](../artifacts/rust-benchmark/classic/docx/report/comparison_report.md) | Résultats de comparaison visuelle Rust des documents |
 | [Procédure de benchmark Rust](../scripts/Run-Rust-Benchmark.ps1) | Génère la couverture des tests et les rapports comparatifs |
+| [Gouvernance communautaire](../GOVERNANCE.md) | Décisions, rôles, votes et sélection des mainteneurs |
+| [Feuille de route](../ROADMAP.md) | Périmètre du projet, état des implémentations et priorités |
+| [Sécurité](../SECURITY.md) | Signalement privé des vulnérabilités et versions prises en charge |
+| [Contribuer](../CONTRIBUTING.md) | Environnement, tests, revues et exigences de provenance |
 | [GitHub Releases](https://github.com/mini-software/MiniPdf/releases) | Paquets et binaires autonomes |
 | [Issues](https://github.com/mini-software/MiniPdf/issues) | Bogues, rapports de compatibilité et demandes de fonctionnalités |
 

--- a/documents/README.it.md
+++ b/documents/README.it.md
@@ -110,6 +110,10 @@ Entrambi i percorsi richiedono Git, Python 3.10+ e LibreOffice. .NET richiede .N
 | [Benchmark XLSX Rust](../artifacts/rust-benchmark/classic/xlsx/report/comparison_report.md) | Risultati del confronto visivo Rust per i fogli di calcolo |
 | [Benchmark DOCX Rust](../artifacts/rust-benchmark/classic/docx/report/comparison_report.md) | Risultati del confronto visivo Rust per i documenti |
 | [Flusso benchmark Rust](../scripts/Run-Rust-Benchmark.ps1) | Genera copertura dei test e report comparativi |
+| [Governance della comunità](../GOVERNANCE.md) | Decisioni, ruoli, votazioni e selezione dei maintainer |
+| [Roadmap](../ROADMAP.md) | Ambito del progetto, stato delle implementazioni e priorità |
+| [Sicurezza](../SECURITY.md) | Segnalazione privata delle vulnerabilità e versioni supportate |
+| [Contribuire](../CONTRIBUTING.md) | Ambiente, test, revisioni e requisiti di provenienza |
 | [GitHub Releases](https://github.com/mini-software/MiniPdf/releases) | Pacchetti e binari autonomi |
 | [Issues](https://github.com/mini-software/MiniPdf/issues) | Bug, problemi di compatibilità e richieste di funzionalità |
 

--- a/documents/README.ja.md
+++ b/documents/README.ja.md
@@ -110,6 +110,10 @@ Rust 実装に取り組む場合は `dotnet` を `rust` に置き換えてくだ
 | [Rust XLSX ベンチマーク](../artifacts/rust-benchmark/classic/xlsx/report/comparison_report.md) | Rust スプレッドシートの視覚比較結果 |
 | [Rust DOCX ベンチマーク](../artifacts/rust-benchmark/classic/docx/report/comparison_report.md) | Rust ドキュメントの視覚比較結果 |
 | [Rust ベンチマーク手順](../scripts/Run-Rust-Benchmark.ps1) | フィクスチャ範囲と比較レポートを生成 |
+| [コミュニティガバナンス](../GOVERNANCE.md) | 意思決定、役割、投票、メンテナー選出 |
+| [ロードマップ](../ROADMAP.md) | プロジェクト範囲、実装状況、現在の優先事項 |
+| [セキュリティ](../SECURITY.md) | 脆弱性の非公開報告とサポート対象バージョン |
+| [コントリビューション](../CONTRIBUTING.md) | 開発環境、テスト、レビュー、来歴要件 |
 | [GitHub Releases](https://github.com/mini-software/MiniPdf/releases) | パッケージと単体バイナリ |
 | [Issues](https://github.com/mini-software/MiniPdf/issues) | バグ、互換性レポート、機能リクエスト |
 

--- a/documents/README.ko.md
+++ b/documents/README.ko.md
@@ -110,6 +110,10 @@ Rust 구현에 기여하려면 `dotnet`을 `rust`로 바꾸세요. 공통 PowerS
 | [Rust XLSX 벤치마크](../artifacts/rust-benchmark/classic/xlsx/report/comparison_report.md) | Rust 스프레드시트 시각 비교 결과 |
 | [Rust DOCX 벤치마크](../artifacts/rust-benchmark/classic/docx/report/comparison_report.md) | Rust 문서 시각 비교 결과 |
 | [Rust 벤치마크 절차](../scripts/Run-Rust-Benchmark.ps1) | 픽스처 범위 및 비교 보고서 생성 |
+| [커뮤니티 거버넌스](../GOVERNANCE.md) | 의사 결정, 역할, 투표 및 메인테이너 선정 |
+| [로드맵](../ROADMAP.md) | 프로젝트 범위, 구현 상태 및 현재 우선순위 |
+| [보안](../SECURITY.md) | 비공개 취약점 신고 및 지원 버전 |
+| [기여 가이드](../CONTRIBUTING.md) | 개발 환경, 테스트, 리뷰 및 출처 요건 |
 | [GitHub Releases](https://github.com/mini-software/MiniPdf/releases) | 패키지 및 독립 실행형 바이너리 |
 | [Issues](https://github.com/mini-software/MiniPdf/issues) | 버그, 호환성 보고 및 기능 요청 |
 

--- a/documents/README.zh-CN.md
+++ b/documents/README.zh-CN.md
@@ -110,6 +110,10 @@ Read CONTRIBUTING.md and run the MiniPdf contribution loop for dotnet from start
 | [Rust XLSX 基准](../artifacts/rust-benchmark/classic/xlsx/report/comparison_report.md) | Rust 电子表格视觉比较结果 |
 | [Rust DOCX 基准](../artifacts/rust-benchmark/classic/docx/report/comparison_report.md) | Rust 文档视觉比较结果 |
 | [Rust 基准流程](../scripts/Run-Rust-Benchmark.ps1) | 生成测试覆盖与比较报告 |
+| [社区治理](../GOVERNANCE.md) | 决策、角色、投票和维护者选任 |
+| [路线图](../ROADMAP.md) | 项目范围、实现状态和当前优先事项 |
+| [安全政策](../SECURITY.md) | 私密漏洞报告和支持版本 |
+| [贡献指南](../CONTRIBUTING.md) | 开发环境、测试、审查和来源要求 |
 | [GitHub Releases](https://github.com/mini-software/MiniPdf/releases) | 软件包与独立二进制文件 |
 | [Issues](https://github.com/mini-software/MiniPdf/issues) | 缺陷、兼容性报告和功能建议 |
 

--- a/documents/README.zh-TW.md
+++ b/documents/README.zh-TW.md
@@ -110,6 +110,10 @@ Read CONTRIBUTING.md and run the MiniPdf contribution loop for dotnet from start
 | [Rust XLSX 基準](../artifacts/rust-benchmark/classic/xlsx/report/comparison_report.md) | Rust 試算表視覺比較結果 |
 | [Rust DOCX 基準](../artifacts/rust-benchmark/classic/docx/report/comparison_report.md) | Rust 文件視覺比較結果 |
 | [Rust 基準流程](../scripts/Run-Rust-Benchmark.ps1) | 產生測試涵蓋率與比較報告 |
+| [社群治理](../GOVERNANCE.md) | 決策、角色、投票與維護者選任 |
+| [路線圖](../ROADMAP.md) | 專案範圍、實作狀態與目前優先事項 |
+| [安全政策](../SECURITY.md) | 私密漏洞回報與支援版本 |
+| [貢獻指南](../CONTRIBUTING.md) | 開發環境、測試、審查與來源要求 |
 | [GitHub Releases](https://github.com/mini-software/MiniPdf/releases) | 套件與獨立二進位檔 |
 | [Issues](https://github.com/mini-software/MiniPdf/issues) | 錯誤、相容性報告與功能建議 |
 


### PR DESCRIPTION
## Summary

- add governance, maintainer, security, code of conduct, and roadmap policies
- make contribution guidance human-first and add a standard pull request checklist
- link the policies from the English and translated READMEs
- document the current single-maintainer sustainability risk and ASF-readiness goals without claiming ASF affiliation

## Validation

- git diff --cached --check before commit
- Markdown structure and local-link validation
- VS Code diagnostics reported no errors for the changed documentation
- verified each translated resource table links to the governance documents
- enabled and verified GitHub private vulnerability reporting

Documentation-only change; application tests were not required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added contribution, governance, maintainer, roadmap, security, and code-of-conduct documentation.
  - Added a pull request template with validation and review checklists.
  - Expanded contribution guidance with automated rendering workflows, safety gates, confidentiality, licensing, and vulnerability-reporting information.
  - Documented supported security-report categories and response expectations.
  - Added links to project resources in the English, French, Italian, Japanese, Korean, Simplified Chinese, and Traditional Chinese README files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->