### PR TITLE
Prepare Java 0.1.0 for Maven Central

### DIFF
--- a/minipdf-java/minipdf-cli/pom.xml
+++ b/minipdf-java/minipdf-cli/pom.xml
@@ -5,9 +5,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.minisoftware</groupId>
+        <groupId>io.github.shps951023</groupId>
         <artifactId>minipdf-java-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
     </parent>
 
     <artifactId>minipdf-cli</artifactId>

--- a/minipdf-java/minipdf-cli/src/main/java/io/github/minisoftware/minipdf/cli/MiniPdfCommand.java
+++ b/minipdf-java/minipdf-cli/src/main/java/io/github/minisoftware/minipdf/cli/MiniPdfCommand.java
@@ -20,7 +20,7 @@ import java.util.concurrent.Callable;
 
 @Command(
         name = "minipdf",
-        version = "minipdf-java 0.1.0-SNAPSHOT",
+    version = "minipdf-java 0.1.0",
         description = "Convert XLSX and DOCX files to PDF with the Java MiniPdf engine.",
         mixinStandardHelpOptions = true,
         subcommands = MiniPdfCommand.ConvertCommand.class)

--- a/minipdf-java/minipdf/pom.xml
+++ b/minipdf-java/minipdf/pom.xml
@@ -5,9 +5,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.minisoftware</groupId>
+        <groupId>io.github.shps951023</groupId>
         <artifactId>minipdf-java-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0</version>
     </parent>
 
     <artifactId>minipdf</artifactId>

--- a/minipdf-java/pom.xml
+++ b/minipdf-java/pom.xml
@@ -4,14 +4,39 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.github.minisoftware</groupId>
+    <groupId>io.github.shps951023</groupId>
     <artifactId>minipdf-java-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.0</version>
     <packaging>pom</packaging>
 
     <name>MiniPdf for Java</name>
     <description>Native Java Office-to-PDF conversion.</description>
     <url>https://github.com/mini-software/MiniPdf</url>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>shps951023</id>
+            <name>Wei Lin</name>
+            <url>https://github.com/shps951023</url>
+            <organization>MiniSoftware</organization>
+            <organizationUrl>https://github.com/mini-software</organizationUrl>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:https://github.com/mini-software/MiniPdf.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/mini-software/MiniPdf.git</developerConnection>
+        <url>https://github.com/mini-software/MiniPdf</url>
+        <tag>HEAD</tag>
+    </scm>
 
     <modules>
         <module>minipdf</module>
@@ -23,6 +48,10 @@
         <maven.compiler.release>17</maven.compiler.release>
         <junit.version>5.13.4</junit.version>
         <picocli.version>4.7.7</picocli.version>
+        <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
+        <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
+        <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
+        <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -61,4 +90,65 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>${maven-source-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>${maven-javadoc-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>${maven-gpg-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${central-publishing-maven-plugin.version}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Prepare the initial Java release for Maven Central under `io.github.shps951023`.

- set the reactor and module version to `0.1.0`
- add required license, developer, and SCM metadata
- attach source and Javadoc JARs
- sign release artifacts with GPG
- configure Sonatype Central Portal publishing
- update the CLI-reported version

Validation: `mvn -B -ntp -Prelease clean verify` passes with signed artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the project and command-line tool to version 0.1.0.
  - Removed snapshot labeling from the reported application version.

- **Distribution**
  - Added support for publishing official release artifacts to Maven Central.
  - Release packages now include source and API documentation archives.
  - Published artifacts are signed to improve authenticity and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->