### PR TITLE
Fix npm musl artifact builds

### DIFF
--- a/minipdf-node/package.json
+++ b/minipdf-node/package.json
@@ -25,8 +25,10 @@
   },
   "scripts": {
     "artifacts": "napi artifacts",
-    "build": "napi build --platform --release && node scripts/postprocess-loader.js",
-    "build:debug": "napi build --platform && node scripts/postprocess-loader.js",
+    "build": "napi build --platform --release",
+    "postbuild": "node scripts/postprocess-loader.js",
+    "build:debug": "napi build --platform",
+    "postbuild:debug": "node scripts/postprocess-loader.js",
     "create-npm-dir": "napi create-npm-dir -t .",
     "prepare-release": "node scripts/prepare-release.js",
     "test": "node --test test/index.test.js"


### PR DESCRIPTION
The initial npm publication assembled only six of eight native addons because npm appended workflow target arguments to the loader postprocessor instead of `napi build`. Both musl jobs consequently uploaded GNU binaries that were overwritten during artifact download.

This moves loader post-processing to npm lifecycle hooks so `--target` and `--zig` reach napi while preserving normal build behavior.

Validation:
- `npm run build -- --target x86_64-pc-windows-msvc`
- `npm test` (8 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflows so post-build processing runs automatically after standard and debug builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->