### PR TITLE
Pin Rust for ARM64 musl npm builds

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -73,6 +73,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: ${{ matrix.target == 'aarch64-unknown-linux-musl' && '1.97.1' || 'stable' }}
           targets: ${{ matrix.target }}
 
       - name: Setup Zig


### PR DESCRIPTION
Rust 1.98 adds `--fix-cortex-a53-843419` to the `aarch64-unknown-linux-musl` target. napi-rs 2 invokes `cargo build` with a Zig linker, bypassing cargo-zigbuild 0.23's filter, so Zig rejects the new argument.

Pin only the affected target to Rust 1.97.1 while retaining stable Rust for the other seven release targets.

The failed publication stopped before any `npm publish` command ran.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the build workflow to use Rust 1.97.1 for ARM64 Linux musl builds.
  - Other build targets continue using the stable Rust toolchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->