### PR TITLE
Fix npm publication and refresh multilingual contribution docs

### DIFF
--- a/.agents/skills/minipdf-contribution/SKILL.md
+++ b/.agents/skills/minipdf-contribution/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: minipdf-contribution
-description: "Run the vendor-neutral MiniPdf .NET or Rust rendering contribution loop with automatic low-score selection, three-attempt rollback, full regression validation, and PR preparation. Use when: donating compute, improving visual benchmark scores, or preparing a benchmark-backed MiniPdf contribution."
-argument-hint: "Choose dotnet or rust"
+description: "Run the vendor-neutral MiniPdf .NET or Rust rendering contribution loop with automatic toolchain detection, random implementation selection, low-score selection, three-attempt rollback, full regression validation, and PR preparation. Use when: donating compute, improving visual benchmark scores, or preparing a benchmark-backed MiniPdf contribution."
+argument-hint: "Optionally choose dotnet or rust"
 ---
 
 # MiniPdf Contribution Loop
@@ -9,7 +9,9 @@ argument-hint: "Choose dotnet or rust"
 Read `CONTRIBUTING.md`, especially "Donate Compute with Any Coding Agent", and
 execute `scripts/Invoke-MiniPdfContributionLoop.ps1` as the source of truth.
 
-Choose `dotnet` or `rust`, then carry the workflow through Start, focused
-Begin/Evaluate attempts, Validate, and Pr. Make one evidence-driven root-cause
-change per attempt. Preserve unrelated changes. Never commit, push, fork, or
-open a pull request without explicit user approval.
+Run `Start` without an implementation to detect installed .NET and Rust
+toolchains and randomly choose an available implementation, or explicitly pass
+`dotnet` or `rust`. Then carry the workflow through focused Begin/Evaluate
+attempts, Validate, and Pr. Make one evidence-driven root-cause change per
+attempt. Preserve unrelated changes. Never commit, push, fork, or open a pull
+request without explicit user approval.

--- a/.claude/commands/minipdf-contribution.md
+++ b/.claude/commands/minipdf-contribution.md
@@ -6,8 +6,9 @@ argument-hint: "[dotnet|rust]"
 Read `CONTRIBUTING.md`, especially "Donate Compute with Any Coding Agent".
 Requested implementation: `$ARGUMENTS`
 
-Use the requested implementation from the command arguments, defaulting to
-`dotnet` when omitted. Execute the vendor-neutral
+Use the requested implementation from the command arguments. When omitted, let
+the controller detect installed toolchains and randomly choose an available
+implementation. Execute the vendor-neutral
 `scripts/Invoke-MiniPdfContributionLoop.ps1` workflow end to end: Start, up to
 three Begin/Evaluate attempts per selected case, Validate, and Pr. Diagnose and
 fix root causes between Begin and Evaluate. Preserve unrelated changes, and do

--- a/.cursor/commands/minipdf-contribution.md
+++ b/.cursor/commands/minipdf-contribution.md
@@ -5,8 +5,9 @@ description: Run the automated MiniPdf rendering contribution loop for .NET or R
 Read `CONTRIBUTING.md`, especially "Donate Compute with Any Coding Agent".
 Requested implementation: `$ARGUMENTS`
 
-Infer `dotnet` or `rust` from the command arguments, defaulting to `dotnet` when
-omitted. Execute `scripts/Invoke-MiniPdfContributionLoop.ps1` through Start,
+Infer `dotnet` or `rust` from the command arguments. When omitted, let the
+controller detect installed toolchains and randomly choose an available
+implementation. Execute `scripts/Invoke-MiniPdfContributionLoop.ps1` through Start,
 Begin/Evaluate (at most three attempts per selected case), Validate, and Pr.
 Diagnose and fix the root cause between Begin and Evaluate. Preserve unrelated
 changes, and do not commit, push, fork, or create the pull request without

--- a/.github/skills/skill-minipdf-contribution/SKILL.md
+++ b/.github/skills/skill-minipdf-contribution/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: skill-minipdf-contribution
-description: "Run an automated .NET or Rust MiniPdf contribution loop that selects the two largest XLSX or DOCX visual differences, attempts each fix up to three times with rollback, runs full regression checks, and prepares or creates a PR. Use when: contributing compute time, fixing low-score Office-to-PDF images, running the self-evolution loop, or preparing a benchmark-backed MiniPdf PR."
-argument-hint: "Choose .NET or Rust; optionally specify XLSX or DOCX, a benchmark case, or a score threshold"
+description: "Run an automated .NET or Rust MiniPdf contribution loop that detects installed toolchains, randomly selects an available implementation, selects the two largest XLSX or DOCX visual differences, attempts each fix up to three times with rollback, runs full regression checks, and prepares or creates a PR. Use when: contributing compute time, fixing low-score Office-to-PDF images, running the self-evolution loop, or preparing a benchmark-backed MiniPdf PR."
+argument-hint: "Optionally choose .NET or Rust, a format, a benchmark case, or a score threshold"
 user-invocable: true
 disable-model-invocation: false
 ---
 
 # MiniPdf Contribution Loop
 
-Turn local compute time into a focused, reproducible MiniPdf rendering improvement for either implementation. This Copilot skill is one adapter for the vendor-neutral workflow in `CONTRIBUTING.md`; Claude Code, Cursor, Codex, and terminal agents use the same controller. In VS Code Chat, run `/skill-minipdf-contribution .NET` or `/skill-minipdf-contribution Rust`.
+Turn local compute time into a focused, reproducible MiniPdf rendering improvement for either implementation. This Copilot skill is one adapter for the vendor-neutral workflow in `CONTRIBUTING.md`; Claude Code, Cursor, Codex, and terminal agents use the same controller. In VS Code Chat, run `/skill-minipdf-contribution` for automatic selection, or append `.NET` or `Rust` to choose explicitly.
 
 ## Automatic Path
 
@@ -16,12 +16,10 @@ Run this once from the repository root:
 
 ```powershell
 $loop = ".\scripts\Invoke-MiniPdfContributionLoop.ps1"
-& $loop -Action Start -Implementation dotnet
-# or
-& $loop -Action Start -Implementation rust
+& $loop -Action Start
 ```
 
-`.NET` is the default when `-Implementation` is omitted. `Start` requires a clean working tree, runs implementation-specific preflight, installs benchmark Python packages, creates a local `improve/<implementation>-visual-parity-*` branch, builds fresh isolated XLSX/DOCX baselines for the current HEAD, selects the two documents with the lowest page-level visual scores for that renderer, and stores the choice in `.git/minipdf-contribution-loop/`.
+When `-Implementation` is omitted, `Start` detects `dotnet` and `cargo` and randomly chooses one installed implementation. Pass `-Implementation dotnet` or `-Implementation rust` to override the choice. `Start` requires a clean working tree, runs implementation-specific preflight, installs benchmark Python packages, creates a local `improve/<implementation>-visual-parity-*` branch, builds fresh isolated XLSX/DOCX baselines for the current HEAD, selects the two documents with the lowest page-level visual scores for that renderer, and stores the choice in `.git/minipdf-contribution-loop/`.
 
 For Rust, `Start` first builds fresh isolated XLSX and DOCX baseline reports from the shared classic corpus. The current Rust benchmark uses Microsoft 365 as the primary scored reference and LibreOffice as an auxiliary reference. It therefore requires Cargo, desktop Excel and Word, Python, and LibreOffice. The .NET path requires the .NET SDK, Python, and LibreOffice.
 

--- a/.github/skills/skill-minipdf-contribution/scripts/contribution-loop.ps1
+++ b/.github/skills/skill-minipdf-contribution/scripts/contribution-loop.ps1
@@ -3,8 +3,8 @@ param(
     [Parameter(Mandatory)]
     [ValidateSet("Start", "Begin", "Evaluate", "Validate", "Pr", "Status")]
     [string]$Action,
-    [ValidateSet("dotnet", "rust")]
-    [string]$Implementation = "dotnet",
+    [ValidateSet("auto", "dotnet", "rust")]
+    [string]$Implementation = "auto",
     [ValidateSet("xlsx", "docx")]
     [string]$Format,
     [string]$CaseName,
@@ -341,6 +341,7 @@ switch ($Action) {
         if ($status.Count -gt 0) {
             throw "Start requires a clean working tree so failed attempts can be restored without losing user work."
         }
+        $Implementation = & (Join-Path $PSScriptRoot "resolve-implementation.ps1") -Implementation $Implementation
         $preflightJson = & (Join-Path $PSScriptRoot "preflight.ps1") -Implementation $Implementation -Json
         $preflight = ($preflightJson | Out-String) | ConvertFrom-Json
         if (-not $preflight.Ready) { throw "Preflight failed. Follow the reported setup guidance and run Start again." }

--- a/.github/skills/skill-minipdf-contribution/scripts/resolve-implementation.ps1
+++ b/.github/skills/skill-minipdf-contribution/scripts/resolve-implementation.ps1
@@ -1,0 +1,23 @@
+[CmdletBinding()]
+param(
+    [ValidateSet("auto", "dotnet", "rust")]
+    [string]$Implementation = "auto"
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+if ($Implementation -ne "auto") {
+    return $Implementation
+}
+
+$available = @(
+    if (Get-Command dotnet -ErrorAction SilentlyContinue) { "dotnet" }
+    if (Get-Command cargo -ErrorAction SilentlyContinue) { "rust" }
+)
+
+if ($available.Count -eq 0) {
+    throw "Automatic implementation selection requires the .NET SDK or Rust/Cargo."
+}
+
+return Get-Random -InputObject $available

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,9 +40,12 @@ All coding agents, including Copilot, Claude Code, Cursor, and Codex, must use
 the vendor-neutral workflow in `CONTRIBUTING.md`. The executable entry point is:
 
 ```powershell
-scripts/Invoke-MiniPdfContributionLoop.ps1 -Action Start -Implementation dotnet
-scripts/Invoke-MiniPdfContributionLoop.ps1 -Action Start -Implementation rust
+scripts/Invoke-MiniPdfContributionLoop.ps1 -Action Start
 ```
+
+The default detects installed .NET and Rust toolchains and randomly chooses an
+available implementation. Pass `-Implementation dotnet` or
+`-Implementation rust` to override it.
 
 Preserve unrelated changes. Do not commit, push, fork, or open a pull request
 without explicit user approval.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,18 +128,19 @@ Cursor, and Codex. The easiest way to start is to paste this prompt into the
 agent chat:
 
 ```text
-Read CONTRIBUTING.md and run the MiniPdf contribution loop for dotnet from start to finish. Diagnose and improve the automatically selected benchmark cases, validate all changes, and prepare the pull request. Do not commit, push, fork, or open a pull request without my explicit approval.
+Read CONTRIBUTING.md and run the MiniPdf contribution loop from start to finish. Detect the installed supported language toolchains, randomly choose one available implementation, diagnose and improve the automatically selected benchmark cases, validate all changes, and prepare the pull request. Do not commit, push, fork, or open a pull request without my explicit approval.
 ```
 
-Replace `dotnet` with `rust` to work on the Rust implementation. The agent
-integrations are convenience prompts; the workflow and safety gates live in
-one vendor-neutral command:
+The agent integrations are convenience prompts; the workflow and safety gates
+live in one vendor-neutral command. By default it detects `dotnet` and `cargo`
+and randomly chooses one installed implementation:
 
 ```powershell
-# Choose one implementation.
-.\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start -Implementation dotnet
-.\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start -Implementation rust
+.\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start
 ```
+
+Pass `-Implementation dotnet` or `-Implementation rust` to choose explicitly.
+The selected implementation is stored in the loop state for subsequent actions.
 
 `Start` requires a clean working tree. It checks prerequisites, creates an
 implementation-specific branch, builds fresh XLSX and DOCX baselines, and
@@ -173,10 +174,10 @@ request still require explicit user approval.
 
 | Agent | Shortcut |
 |---|---|
-| GitHub Copilot | `/skill-minipdf-contribution .NET` or `/skill-minipdf-contribution Rust` |
-| Claude Code | `/minipdf-contribution dotnet` or `/minipdf-contribution rust` |
-| Cursor | `/minipdf-contribution dotnet` or `/minipdf-contribution rust` |
-| Codex | Ask: `Run the MiniPdf contribution loop for dotnet` or `... for rust` |
+| GitHub Copilot | `/skill-minipdf-contribution` (auto) or append `.NET`/`Rust` |
+| Claude Code | `/minipdf-contribution` (auto) or append `dotnet`/`rust` |
+| Cursor | `/minipdf-contribution` (auto) or append `dotnet`/`rust` |
+| Codex | Ask: `Run the MiniPdf contribution loop` (auto) or specify an implementation |
 | Any terminal agent | Run the vendor-neutral PowerShell commands above |
 
 Agents must preserve unrelated changes and must not commit, push, fork, or open

--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@
 
 # MiniPdf
 
-**Lightweight Office-to-PDF libraries and command-line tools for .NET and Rust.**
+**Lightweight Office-to-PDF libraries and command-line tools for .NET, Rust, Java, Python, Node.js, and Go.**
 
 <p>
 <a href="https://www.nuget.org/packages/MiniPdf"><img src="https://img.shields.io/nuget/v/MiniPdf.svg" alt="NuGet"></a>
 <a href="https://crates.io/crates/minipdf"><img src="https://img.shields.io/crates/v/minipdf.svg" alt="crates.io"></a>
+<a href="https://central.sonatype.com/artifact/io.github.shps951023/minipdf"><img src="https://img.shields.io/maven-central/v/io.github.shps951023/minipdf.svg" alt="Maven Central"></a>
+<a href="https://pypi.org/project/minipdf/"><img src="https://img.shields.io/pypi/v/minipdf.svg" alt="PyPI"></a>
+<a href="https://www.npmjs.com/package/minipdf"><img src="https://img.shields.io/npm/v/minipdf.svg" alt="npm"></a>
+<a href="https://pkg.go.dev/github.com/mini-software/MiniPdf/minipdf-go"><img src="https://pkg.go.dev/badge/github.com/mini-software/MiniPdf/minipdf-go.svg" alt="Go Reference"></a>
 <a href="https://github.com/mini-software/MiniPdf"><img src="https://img.shields.io/github/stars/mini-software/MiniPdf?logo=github" alt="GitHub stars"></a>
 <a href="https://doi.org/10.5281/zenodo.22057294"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.22057294.svg" alt="DOI"></a>
 <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
@@ -26,11 +30,14 @@ implementation that matches your project.
 
 ## Choose an implementation
 
-| | .NET | Rust |
-|---|---|---|
-| Inputs | XLSX, DOCX, PPTX | XLSX, DOCX |
-| Interfaces | .NET library, CLI, standalone Native AOT binaries | Rust crate, CLI |
-| Documentation | **[Open the .NET guide](documents/README.nuget.md)** | **[Open the Rust guide](minipdf-rs/README.md)** |
+| Implementation | Inputs | Interfaces | Maturity | Documentation |
+|---|---|---|---|---|
+| .NET | XLSX, DOCX, PPTX | Library, CLI, Native AOT binaries | Stable | **[.NET guide](documents/README.nuget.md)** |
+| Rust | XLSX, DOCX, PPTX | Crate, CLI | Experimental | **[Rust guide](minipdf-rs/README.md)** |
+| Java | XLSX, DOCX | Library, CLI | Experimental | **[Java source](minipdf-java/)** |
+| Python | DOCX | Package, CLI | Experimental | **[Python guide](minipdf-python/README.md)** |
+| Node.js | XLSX, DOCX, PPTX | Native package | Experimental | **[Node.js guide](minipdf-node/README.md)** |
+| Go | XLSX, DOCX, PPTX | Package, CLI | Experimental | **[Go guide](minipdf-go/README.md)** |
 
 ## Quick start
 
@@ -71,15 +78,77 @@ minipdf::convert_to_pdf("report.docx", "report.pdf")?;
 minipdf report.docx -o report.pdf
 ```
 
-The [Rust guide](minipdf-rs/README.md) documents the crate API, CLI, supported
+[The Rust guide](minipdf-rs/README.md) documents the crate API, CLI, supported
 features, known gaps, and development workflow.
+
+### Java
+
+```xml
+<dependency>
+	<groupId>io.github.shps951023</groupId>
+	<artifactId>minipdf</artifactId>
+	<version>0.1.0</version>
+</dependency>
+```
+
+```java
+import io.github.minisoftware.minipdf.MiniPdf;
+import java.nio.file.Path;
+
+MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
+```
+
+### Python
+
+```bash
+pip install minipdf
+```
+
+```python
+import minipdf
+
+minipdf.convert_to_pdf("report.docx", "report.pdf")
+```
+
+The [Python guide](minipdf-python/README.md) lists the current DOCX feature scope and CLI options.
+
+### Node.js
+
+```bash
+npm install minipdf
+```
+
+```javascript
+const minipdf = require('minipdf')
+
+minipdf.convertToPdf('report.docx', 'report.pdf')
+```
+
+The [Node.js guide](minipdf-node/README.md) covers in-memory conversion, page sizing, font registration, and supported native platforms.
+
+### Go
+
+```bash
+go get github.com/mini-software/MiniPdf/minipdf-go@latest
+```
+
+```go
+import minipdf "github.com/mini-software/MiniPdf/minipdf-go"
+
+if err := minipdf.ConvertToPDF("report.docx", "report.pdf"); err != nil {
+	panic(err)
+}
+```
+
+The [Go guide](minipdf-go/README.md) documents the package, native CLI, current rendering scope, and release tags.
 
 ## Why MiniPdf
 
 - **No office suite required**: conversion runs inside your application or CLI.
 - **Small deployment surface**: minimal dependencies and no external process.
 - **Server and CI friendly**: works in containers, cloud services, and pipelines.
-- **Native command-line options**: .NET Native AOT releases and a Rust CLI.
+- **Multiple language options**: use MiniPdf from .NET, Rust, Java, Python, Node.js, or Go.
+- **Native command-line options**: available for .NET, Rust, Java, Python, and Go.
 - **Open development**: Apache 2.0 licensed with reproducible visual benchmarks.
 
 MiniPdf targets practical document conversion, not complete Microsoft Office
@@ -93,16 +162,18 @@ coding agent that can edit files and run PowerShell. The easiest way to
 contribute is to paste this prompt into the agent chat:
 
 ```text
-Read CONTRIBUTING.md and run the MiniPdf contribution loop for dotnet from start to finish. Diagnose and improve the automatically selected benchmark cases, validate all changes, and prepare the pull request. Do not commit, push, fork, or open a pull request without my explicit approval.
+Read CONTRIBUTING.md and run the MiniPdf contribution loop from start to finish. Detect the installed supported language toolchains, randomly choose one available implementation, diagnose and improve the automatically selected benchmark cases, validate all changes, and prepare the pull request. Do not commit, push, fork, or open a pull request without my explicit approval.
 ```
 
-Replace `dotnet` with `rust` to work on the Rust implementation. The universal
-PowerShell entry points are:
+The universal PowerShell entry point detects `dotnet` and `cargo`, then randomly
+chooses one of the installed implementations:
 
 ```powershell
-.\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start -Implementation dotnet
-.\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start -Implementation rust
+.\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start
 ```
+
+Pass `-Implementation dotnet` or `-Implementation rust` to override the random
+choice. The selected implementation is stored for every later action in the run.
 
 The contribution loop checks the toolchain, installs benchmark Python packages,
 creates a local branch, and selects the chosen renderer's two lowest-scoring
@@ -126,6 +197,10 @@ opens a PR without your approval.
 | [Online demo](https://mini-software.github.io/MiniPdf/) | Try conversion in a browser |
 | [.NET documentation](documents/README.nuget.md) | Stable library and CLI usage |
 | [Rust documentation](minipdf-rs/README.md) | Experimental crate and CLI usage |
+| [Java implementation](minipdf-java/) | Experimental Maven library and CLI source |
+| [Python documentation](minipdf-python/README.md) | Experimental package and CLI usage |
+| [Node.js documentation](minipdf-node/README.md) | Experimental native package usage |
+| [Go documentation](minipdf-go/README.md) | Experimental package and CLI usage |
 | [.NET XLSX benchmark](tests/MiniPdf.Benchmark/reports/comparison_report.md) | Visual comparison results for spreadsheets |
 | [.NET DOCX benchmark](tests/MiniPdf.Benchmark/reports_docx/comparison_report.md) | Visual comparison results for documents |
 | [Rust XLSX benchmark](artifacts/rust-benchmark/classic/xlsx/report/comparison_report.md) | Rust spreadsheet visual comparison results |

--- a/documents/README.fr.md
+++ b/documents/README.fr.md
@@ -2,11 +2,15 @@
 
 # MiniPdf
 
-**Bibliothèques et outils en ligne de commande légers pour convertir des documents Office en PDF avec .NET et Rust.**
+**Bibliothèques et outils en ligne de commande légers pour convertir des documents Office en PDF avec .NET, Rust, Java, Python, Node.js et Go.**
 
 <p>
 <a href="https://www.nuget.org/packages/MiniPdf"><img src="https://img.shields.io/nuget/v/MiniPdf.svg" alt="NuGet"></a>
 <a href="https://crates.io/crates/minipdf"><img src="https://img.shields.io/crates/v/minipdf.svg" alt="crates.io"></a>
+<a href="https://central.sonatype.com/artifact/io.github.shps951023/minipdf"><img src="https://img.shields.io/maven-central/v/io.github.shps951023/minipdf.svg" alt="Maven Central"></a>
+<a href="https://pypi.org/project/minipdf/"><img src="https://img.shields.io/pypi/v/minipdf.svg" alt="PyPI"></a>
+<a href="https://www.npmjs.com/package/minipdf"><img src="https://img.shields.io/npm/v/minipdf.svg" alt="npm"></a>
+<a href="https://pkg.go.dev/github.com/mini-software/MiniPdf/minipdf-go"><img src="https://pkg.go.dev/badge/github.com/mini-software/MiniPdf/minipdf-go.svg" alt="Go Reference"></a>
 <a href="https://github.com/mini-software/MiniPdf"><img src="https://img.shields.io/github/stars/mini-software/MiniPdf?logo=github" alt="GitHub stars"></a>
 <a href="https://doi.org/10.5281/zenodo.22057294"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.22057294.svg" alt="DOI"></a>
 <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
@@ -24,11 +28,14 @@ MiniPdf convertit directement les documents Office en PDF sans nécessiter Micro
 
 ## Choisir une implémentation
 
-| | .NET | Rust |
-|---|---|---|
-| Entrées | XLSX, DOCX, PPTX | XLSX, DOCX |
-| Interfaces | Bibliothèque .NET, CLI, binaires Native AOT autonomes | Crate Rust, CLI |
-| Documentation | **[Ouvrir le guide .NET](README.nuget.md)** | **[Ouvrir le guide Rust](../minipdf-rs/README.md)** |
+| Implémentation | Entrées | Interfaces | Maturité | Documentation |
+|---|---|---|---|---|
+| .NET | XLSX, DOCX, PPTX | Bibliothèque, CLI, binaires Native AOT | Stable | **[Guide .NET](README.nuget.md)** |
+| Rust | XLSX, DOCX, PPTX | Crate, CLI | Expérimental | **[Guide Rust](../minipdf-rs/README.md)** |
+| Java | XLSX, DOCX | Bibliothèque, CLI | Expérimental | **[Sources Java](../minipdf-java/)** |
+| Python | DOCX | Paquet, CLI | Expérimental | **[Guide Python](../minipdf-python/README.md)** |
+| Node.js | XLSX, DOCX, PPTX | Paquet natif | Expérimental | **[Guide Node.js](../minipdf-node/README.md)** |
+| Go | XLSX, DOCX, PPTX | Paquet, CLI | Expérimental | **[Guide Go](../minipdf-go/README.md)** |
 
 ## Démarrage rapide
 
@@ -70,12 +77,74 @@ minipdf report.docx -o report.pdf
 
 Le [guide Rust](../minipdf-rs/README.md) décrit l'API du crate, la CLI, les fonctions prises en charge, les limites connues et le flux de développement.
 
+### Java
+
+```xml
+<dependency>
+	<groupId>io.github.shps951023</groupId>
+	<artifactId>minipdf</artifactId>
+	<version>0.1.0</version>
+</dependency>
+```
+
+```java
+import io.github.minisoftware.minipdf.MiniPdf;
+import java.nio.file.Path;
+
+MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
+```
+
+### Python
+
+```bash
+pip install minipdf
+```
+
+```python
+import minipdf
+
+minipdf.convert_to_pdf("report.docx", "report.pdf")
+```
+
+Le [guide Python](../minipdf-python/README.md) décrit le périmètre DOCX actuel et les options CLI.
+
+### Node.js
+
+```bash
+npm install minipdf
+```
+
+```javascript
+const minipdf = require('minipdf')
+
+minipdf.convertToPdf('report.docx', 'report.pdf')
+```
+
+Le [guide Node.js](../minipdf-node/README.md) décrit la conversion en mémoire, les tailles de page, l'enregistrement des polices et les plateformes natives prises en charge.
+
+### Go
+
+```bash
+go get github.com/mini-software/MiniPdf/minipdf-go@latest
+```
+
+```go
+import minipdf "github.com/mini-software/MiniPdf/minipdf-go"
+
+if err := minipdf.ConvertToPDF("report.docx", "report.pdf"); err != nil {
+	panic(err)
+}
+```
+
+Le [guide Go](../minipdf-go/README.md) décrit le paquet, la CLI native, le périmètre de rendu actuel et les tags de version.
+
 ## Pourquoi MiniPdf
 
 - **Aucune suite Office requise** : la conversion s'exécute dans l'application ou la CLI.
 - **Déploiement réduit** : peu de dépendances et aucun processus externe.
 - **Adapté aux serveurs et à la CI** : fonctionne dans les conteneurs, services cloud et pipelines.
-- **Options natives en ligne de commande** : versions .NET Native AOT et CLI Rust.
+- **Plusieurs langages disponibles** : utilisez MiniPdf depuis .NET, Rust, Java, Python, Node.js ou Go.
+- **Options natives en ligne de commande** : disponibles pour .NET, Rust, Java, Python et Go.
 
 MiniPdf vise une conversion pratique des documents, et non une compatibilité totale avec la mise en page de Microsoft Office. Les modèles complexes peuvent être rendus différemment ; utilisez la démo en ligne ou les rapports de benchmark pour évaluer des fichiers représentatifs.
 
@@ -84,15 +153,16 @@ MiniPdf vise une conversion pratique des documents, et non une compatibilité to
 Ouvrez un fork ou clone propre dans GitHub Copilot, Claude Code, Cursor, Codex ou tout agent de programmation capable de modifier des fichiers et d'exécuter PowerShell. Le moyen le plus simple de contribuer consiste à coller cette instruction dans le chat de l'Agent :
 
 ```text
-Read CONTRIBUTING.md and run the MiniPdf contribution loop for dotnet from start to finish. Diagnose and improve the automatically selected benchmark cases, validate all changes, and prepare the pull request. Do not commit, push, fork, or open a pull request without my explicit approval.
+Read CONTRIBUTING.md and run the MiniPdf contribution loop from start to finish. Detect the installed supported language toolchains, randomly choose one available implementation, diagnose and improve the automatically selected benchmark cases, validate all changes, and prepare the pull request. Do not commit, push, fork, or open a pull request without my explicit approval.
 ```
 
-Remplacez `dotnet` par `rust` pour travailler sur l'implémentation Rust. Les points d'entrée PowerShell communs sont :
+Le point d'entrée PowerShell détecte `dotnet` et `cargo`, puis choisit aléatoirement l'une des implémentations installées :
 
 ```powershell
-.\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start -Implementation dotnet
-.\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start -Implementation rust
+.\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start
 ```
+
+Passez `-Implementation dotnet` ou `-Implementation rust` pour remplacer le choix aléatoire. L'implémentation sélectionnée est enregistrée dans l'état de la boucle pour toutes les opérations suivantes.
 
 La boucle vérifie les outils, installe les paquets Python du benchmark, crée une branche locale et sélectionne les deux écarts visuels ayant les scores les plus faibles pour le moteur choisi. L'Agent effectue jusqu'à trois tentatives par cas ; sans amélioration du score, les modifications sont automatiquement annulées avant de passer au cas suivant. Une PR n'est autorisée qu'après la réussite de tous les tests de l'implémentation choisie et des benchmarks visuels XLSX/DOCX, sans régression significative.
 
@@ -105,6 +175,10 @@ Les deux parcours nécessitent Git, Python 3.10+ et LibreOffice. .NET nécessite
 | [Démo en ligne](https://mini-software.github.io/MiniPdf/) | Tester la conversion dans le navigateur |
 | [Documentation .NET](README.nuget.md) | Utilisation de la bibliothèque stable et de la CLI |
 | [Documentation Rust](../minipdf-rs/README.md) | Utilisation du crate expérimental et de la CLI |
+| [Implémentation Java](../minipdf-java/) | Sources de la bibliothèque Maven et de la CLI expérimentales |
+| [Documentation Python](../minipdf-python/README.md) | Utilisation du paquet expérimental et de la CLI |
+| [Documentation Node.js](../minipdf-node/README.md) | Utilisation du paquet natif expérimental |
+| [Documentation Go](../minipdf-go/README.md) | Utilisation du paquet expérimental et de la CLI |
 | [Benchmark XLSX .NET](../tests/MiniPdf.Benchmark/reports/comparison_report.md) | Résultats visuels pour les feuilles de calcul |
 | [Benchmark DOCX .NET](../tests/MiniPdf.Benchmark/reports_docx/comparison_report.md) | Résultats visuels pour les documents |
 | [Benchmark XLSX Rust](../artifacts/rust-benchmark/classic/xlsx/report/comparison_report.md) | Résultats de comparaison visuelle Rust des feuilles de calcul |

--- a/documents/README.it.md
+++ b/documents/README.it.md
@@ -2,11 +2,15 @@
 
 # MiniPdf
 
-**Librerie e strumenti da riga di comando leggeri per convertire documenti Office in PDF con .NET e Rust.**
+**Librerie e strumenti da riga di comando leggeri per convertire documenti Office in PDF con .NET, Rust, Java, Python, Node.js e Go.**
 
 <p>
 <a href="https://www.nuget.org/packages/MiniPdf"><img src="https://img.shields.io/nuget/v/MiniPdf.svg" alt="NuGet"></a>
 <a href="https://crates.io/crates/minipdf"><img src="https://img.shields.io/crates/v/minipdf.svg" alt="crates.io"></a>
+<a href="https://central.sonatype.com/artifact/io.github.shps951023/minipdf"><img src="https://img.shields.io/maven-central/v/io.github.shps951023/minipdf.svg" alt="Maven Central"></a>
+<a href="https://pypi.org/project/minipdf/"><img src="https://img.shields.io/pypi/v/minipdf.svg" alt="PyPI"></a>
+<a href="https://www.npmjs.com/package/minipdf"><img src="https://img.shields.io/npm/v/minipdf.svg" alt="npm"></a>
+<a href="https://pkg.go.dev/github.com/mini-software/MiniPdf/minipdf-go"><img src="https://pkg.go.dev/badge/github.com/mini-software/MiniPdf/minipdf-go.svg" alt="Go Reference"></a>
 <a href="https://github.com/mini-software/MiniPdf"><img src="https://img.shields.io/github/stars/mini-software/MiniPdf?logo=github" alt="GitHub stars"></a>
 <a href="https://doi.org/10.5281/zenodo.22057294"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.22057294.svg" alt="DOI"></a>
 <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
@@ -24,11 +28,14 @@ MiniPdf converte direttamente i documenti Office in PDF senza richiedere Microso
 
 ## Scegli un'implementazione
 
-| | .NET | Rust |
-|---|---|---|
-| Input | XLSX, DOCX, PPTX | XLSX, DOCX |
-| Interfacce | Libreria .NET, CLI, binari Native AOT autonomi | Crate Rust, CLI |
-| Documentazione | **[Apri la guida .NET](README.nuget.md)** | **[Apri la guida Rust](../minipdf-rs/README.md)** |
+| Implementazione | Input | Interfacce | Maturità | Documentazione |
+|---|---|---|---|---|
+| .NET | XLSX, DOCX, PPTX | Libreria, CLI, binari Native AOT | Stabile | **[Guida .NET](README.nuget.md)** |
+| Rust | XLSX, DOCX, PPTX | Crate, CLI | Sperimentale | **[Guida Rust](../minipdf-rs/README.md)** |
+| Java | XLSX, DOCX | Libreria, CLI | Sperimentale | **[Sorgenti Java](../minipdf-java/)** |
+| Python | DOCX | Pacchetto, CLI | Sperimentale | **[Guida Python](../minipdf-python/README.md)** |
+| Node.js | XLSX, DOCX, PPTX | Pacchetto nativo | Sperimentale | **[Guida Node.js](../minipdf-node/README.md)** |
+| Go | XLSX, DOCX, PPTX | Pacchetto, CLI | Sperimentale | **[Guida Go](../minipdf-go/README.md)** |
 
 ## Avvio rapido
 
@@ -70,12 +77,74 @@ minipdf report.docx -o report.pdf
 
 La [guida Rust](../minipdf-rs/README.md) descrive API del crate, CLI, funzionalità supportate, limiti noti e flusso di sviluppo.
 
+### Java
+
+```xml
+<dependency>
+	<groupId>io.github.shps951023</groupId>
+	<artifactId>minipdf</artifactId>
+	<version>0.1.0</version>
+</dependency>
+```
+
+```java
+import io.github.minisoftware.minipdf.MiniPdf;
+import java.nio.file.Path;
+
+MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
+```
+
+### Python
+
+```bash
+pip install minipdf
+```
+
+```python
+import minipdf
+
+minipdf.convert_to_pdf("report.docx", "report.pdf")
+```
+
+La [guida Python](../minipdf-python/README.md) descrive l'ambito DOCX attuale e le opzioni CLI.
+
+### Node.js
+
+```bash
+npm install minipdf
+```
+
+```javascript
+const minipdf = require('minipdf')
+
+minipdf.convertToPdf('report.docx', 'report.pdf')
+```
+
+La [guida Node.js](../minipdf-node/README.md) descrive la conversione in memoria, le dimensioni della pagina, la registrazione dei font e le piattaforme native supportate.
+
+### Go
+
+```bash
+go get github.com/mini-software/MiniPdf/minipdf-go@latest
+```
+
+```go
+import minipdf "github.com/mini-software/MiniPdf/minipdf-go"
+
+if err := minipdf.ConvertToPDF("report.docx", "report.pdf"); err != nil {
+	panic(err)
+}
+```
+
+La [guida Go](../minipdf-go/README.md) descrive il pacchetto, la CLI nativa, l'ambito di rendering attuale e i tag di release.
+
 ## Perché MiniPdf
 
 - **Nessuna suite Office richiesta**: la conversione viene eseguita nell'applicazione o nella CLI.
 - **Distribuzione essenziale**: poche dipendenze e nessun processo esterno.
 - **Adatto a server e CI**: funziona in container, servizi cloud e pipeline.
-- **Opzioni native da riga di comando**: release .NET Native AOT e CLI Rust.
+- **Più linguaggi disponibili**: usa MiniPdf da .NET, Rust, Java, Python, Node.js o Go.
+- **Opzioni native da riga di comando**: disponibili per .NET, Rust, Java, Python e Go.
 
 MiniPdf punta alla conversione pratica dei documenti, non alla compatibilità completa con il layout di Microsoft Office. I modelli complessi possono essere visualizzati diversamente; usa la demo online o i report di benchmark per valutare file rappresentativi.
 
@@ -84,15 +153,16 @@ MiniPdf punta alla conversione pratica dei documenti, non alla compatibilità co
 Apri un fork o clone pulito in GitHub Copilot, Claude Code, Cursor, Codex o qualsiasi agente di programmazione capace di modificare file ed eseguire PowerShell. Il modo più semplice per contribuire è incollare questa istruzione nella chat dell'Agent:
 
 ```text
-Read CONTRIBUTING.md and run the MiniPdf contribution loop for dotnet from start to finish. Diagnose and improve the automatically selected benchmark cases, validate all changes, and prepare the pull request. Do not commit, push, fork, or open a pull request without my explicit approval.
+Read CONTRIBUTING.md and run the MiniPdf contribution loop from start to finish. Detect the installed supported language toolchains, randomly choose one available implementation, diagnose and improve the automatically selected benchmark cases, validate all changes, and prepare the pull request. Do not commit, push, fork, or open a pull request without my explicit approval.
 ```
 
-Sostituisci `dotnet` con `rust` per lavorare sull'implementazione Rust. I punti di ingresso PowerShell comuni sono:
+Il punto di ingresso PowerShell rileva `dotnet` e `cargo`, quindi sceglie casualmente una delle implementazioni installate:
 
 ```powershell
-.\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start -Implementation dotnet
-.\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start -Implementation rust
+.\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start
 ```
+
+Passa `-Implementation dotnet` o `-Implementation rust` per ignorare la scelta casuale. L'implementazione selezionata viene salvata nello stato del ciclo per tutte le operazioni successive.
 
 Il ciclo controlla gli strumenti, installa i pacchetti Python per i benchmark, crea un branch locale e seleziona le due differenze visive con il punteggio più basso per il renderer scelto. L'Agent effettua fino a tre tentativi per caso; se il punteggio non migliora, ripristina automaticamente le modifiche e passa al caso successivo. La PR è consentita solo dopo il superamento di tutti i test dell'implementazione scelta e dei benchmark visivi XLSX/DOCX senza regressioni significative.
 
@@ -105,6 +175,10 @@ Entrambi i percorsi richiedono Git, Python 3.10+ e LibreOffice. .NET richiede .N
 | [Demo online](https://mini-software.github.io/MiniPdf/) | Prova la conversione nel browser |
 | [Documentazione .NET](README.nuget.md) | Uso della libreria stabile e della CLI |
 | [Documentazione Rust](../minipdf-rs/README.md) | Uso del crate sperimentale e della CLI |
+| [Implementazione Java](../minipdf-java/) | Sorgenti della libreria Maven e della CLI sperimentali |
+| [Documentazione Python](../minipdf-python/README.md) | Uso del pacchetto sperimentale e della CLI |
+| [Documentazione Node.js](../minipdf-node/README.md) | Uso del pacchetto nativo sperimentale |
+| [Documentazione Go](../minipdf-go/README.md) | Uso del pacchetto sperimentale e della CLI |
 | [Benchmark XLSX .NET](../tests/MiniPdf.Benchmark/reports/comparison_report.md) | Risultati visivi per i fogli di calcolo |
 | [Benchmark DOCX .NET](../tests/MiniPdf.Benchmark/reports_docx/comparison_report.md) | Risultati visivi per i documenti |
 | [Benchmark XLSX Rust](../artifacts/rust-benchmark/classic/xlsx/report/comparison_report.md) | Risultati del confronto visivo Rust per i fogli di calcolo |

--- a/documents/README.ja.md
+++ b/documents/README.ja.md
@@ -2,11 +2,15 @@
 
 # MiniPdf
 
-**.NET と Rust 向けの軽量な Office-to-PDF ライブラリおよびコマンドラインツール。**
+**.NET、Rust、Java、Python、Node.js、Go 向けの軽量な Office-to-PDF ライブラリおよびコマンドラインツール。**
 
 <p>
 <a href="https://www.nuget.org/packages/MiniPdf"><img src="https://img.shields.io/nuget/v/MiniPdf.svg" alt="NuGet"></a>
 <a href="https://crates.io/crates/minipdf"><img src="https://img.shields.io/crates/v/minipdf.svg" alt="crates.io"></a>
+<a href="https://central.sonatype.com/artifact/io.github.shps951023/minipdf"><img src="https://img.shields.io/maven-central/v/io.github.shps951023/minipdf.svg" alt="Maven Central"></a>
+<a href="https://pypi.org/project/minipdf/"><img src="https://img.shields.io/pypi/v/minipdf.svg" alt="PyPI"></a>
+<a href="https://www.npmjs.com/package/minipdf"><img src="https://img.shields.io/npm/v/minipdf.svg" alt="npm"></a>
+<a href="https://pkg.go.dev/github.com/mini-software/MiniPdf/minipdf-go"><img src="https://pkg.go.dev/badge/github.com/mini-software/MiniPdf/minipdf-go.svg" alt="Go Reference"></a>
 <a href="https://github.com/mini-software/MiniPdf"><img src="https://img.shields.io/github/stars/mini-software/MiniPdf?logo=github" alt="GitHub stars"></a>
 <a href="https://doi.org/10.5281/zenodo.22057294"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.22057294.svg" alt="DOI"></a>
 <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
@@ -24,11 +28,14 @@ MiniPdf は、実行時に Microsoft Office、LibreOffice、Adobe Acrobat、COM 
 
 ## 実装を選ぶ
 
-| | .NET | Rust |
-|---|---|---|
-| 入力 | XLSX、DOCX、PPTX | XLSX、DOCX |
-| インターフェイス | .NET ライブラリ、CLI、Native AOT 単体バイナリ | Rust crate、CLI |
-| ドキュメント | **[.NET ガイドを開く](README.nuget.md)** | **[Rust ガイドを開く](../minipdf-rs/README.md)** |
+| 実装 | 入力 | インターフェイス | 成熟度 | ドキュメント |
+|---|---|---|---|---|
+| .NET | XLSX、DOCX、PPTX | ライブラリ、CLI、Native AOT バイナリ | 安定版 | **[.NET ガイド](README.nuget.md)** |
+| Rust | XLSX、DOCX、PPTX | Crate、CLI | 実験版 | **[Rust ガイド](../minipdf-rs/README.md)** |
+| Java | XLSX、DOCX | ライブラリ、CLI | 実験版 | **[Java ソース](../minipdf-java/)** |
+| Python | DOCX | パッケージ、CLI | 実験版 | **[Python ガイド](../minipdf-python/README.md)** |
+| Node.js | XLSX、DOCX、PPTX | ネイティブパッケージ | 実験版 | **[Node.js ガイド](../minipdf-node/README.md)** |
+| Go | XLSX、DOCX、PPTX | パッケージ、CLI | 実験版 | **[Go ガイド](../minipdf-go/README.md)** |
 
 ## クイックスタート
 
@@ -70,12 +77,74 @@ minipdf report.docx -o report.pdf
 
 [Rust ガイド](../minipdf-rs/README.md)では、crate API、CLI、対応範囲、既知の制限、開発手順を説明しています。
 
+### Java
+
+```xml
+<dependency>
+	<groupId>io.github.shps951023</groupId>
+	<artifactId>minipdf</artifactId>
+	<version>0.1.0</version>
+</dependency>
+```
+
+```java
+import io.github.minisoftware.minipdf.MiniPdf;
+import java.nio.file.Path;
+
+MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
+```
+
+### Python
+
+```bash
+pip install minipdf
+```
+
+```python
+import minipdf
+
+minipdf.convert_to_pdf("report.docx", "report.pdf")
+```
+
+[Python ガイド](../minipdf-python/README.md)では、現在の DOCX 対応範囲と CLI オプションを説明しています。
+
+### Node.js
+
+```bash
+npm install minipdf
+```
+
+```javascript
+const minipdf = require('minipdf')
+
+minipdf.convertToPdf('report.docx', 'report.pdf')
+```
+
+[Node.js ガイド](../minipdf-node/README.md)では、メモリ内変換、ページサイズ、フォント登録、対応ネイティブプラットフォームを説明しています。
+
+### Go
+
+```bash
+go get github.com/mini-software/MiniPdf/minipdf-go@latest
+```
+
+```go
+import minipdf "github.com/mini-software/MiniPdf/minipdf-go"
+
+if err := minipdf.ConvertToPDF("report.docx", "report.pdf"); err != nil {
+	panic(err)
+}
+```
+
+[Go ガイド](../minipdf-go/README.md)では、パッケージ、ネイティブ CLI、現在の描画範囲、リリースタグを説明しています。
+
 ## MiniPdf を選ぶ理由
 
 - **Office スイート不要**：変換はアプリケーションまたは CLI 内で実行されます。
 - **小さなデプロイ構成**：依存関係が少なく、外部プロセスも不要です。
 - **サーバーと CI に対応**：コンテナー、クラウドサービス、パイプラインで利用できます。
-- **ネイティブ CLI**：.NET Native AOT リリースと Rust CLI を提供します。
+- **複数言語に対応**：.NET、Rust、Java、Python、Node.js、Go から MiniPdf を利用できます。
+- **ネイティブ CLI**：.NET、Rust、Java、Python、Go で利用できます。
 
 MiniPdf は実用的な文書変換を目的としており、Microsoft Office のレイアウトを完全に再現するものではありません。複雑なテンプレートは表示が異なる場合があるため、オンラインデモやベンチマークレポートで代表的なファイルを評価してください。
 
@@ -84,15 +153,16 @@ MiniPdf は実用的な文書変換を目的としており、Microsoft Office �
 クリーンな fork または clone を GitHub Copilot、Claude Code、Cursor、Codex、またはファイル編集と PowerShell 実行が可能な任意のコーディング Agent で開きます。最も簡単な方法は、次の指示を Agent のチャットに貼り付けることです。
 
 ```text
-Read CONTRIBUTING.md and run the MiniPdf contribution loop for dotnet from start to finish. Diagnose and improve the automatically selected benchmark cases, validate all changes, and prepare the pull request. Do not commit, push, fork, or open a pull request without my explicit approval.
+Read CONTRIBUTING.md and run the MiniPdf contribution loop from start to finish. Detect the installed supported language toolchains, randomly choose one available implementation, diagnose and improve the automatically selected benchmark cases, validate all changes, and prepare the pull request. Do not commit, push, fork, or open a pull request without my explicit approval.
 ```
 
-Rust 実装に取り組む場合は `dotnet` を `rust` に置き換えてください。共通の PowerShell エントリーポイントは次のとおりです。
+共通の PowerShell エントリーポイントは `dotnet` と `cargo` を検出し、インストール済みの実装から 1 つをランダムに選択します。
 
 ```powershell
-.\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start -Implementation dotnet
-.\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start -Implementation rust
+.\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start
 ```
+
+ランダム選択を上書きするには、`-Implementation dotnet` または `-Implementation rust` を指定してください。選択した実装は、このループの後続操作で使用する状態に保存されます。
 
 この貢献ループはツールチェーンを確認し、ベンチマーク用 Python パッケージをインストールしてローカルブランチを作成し、選択したレンダラーで視覚スコアが最も低い差分を 2 件選びます。Agent は各ケースを最大 3 回修正し、スコアが改善しなければ自動的に元へ戻して次へ進みます。選択した実装の全テストと XLSX/DOCX 視覚ベンチマークを通過し、重大な回帰がない場合にのみ PR を作成できます。
 
@@ -105,6 +175,10 @@ Rust 実装に取り組む場合は `dotnet` を `rust` に置き換えてくだ
 | [オンラインデモ](https://mini-software.github.io/MiniPdf/) | ブラウザーで変換を試す |
 | [.NET ドキュメント](README.nuget.md) | 安定版ライブラリと CLI の使用方法 |
 | [Rust ドキュメント](../minipdf-rs/README.md) | 実験版 crate と CLI の使用方法 |
+| [Java 実装](../minipdf-java/) | 実験版 Maven ライブラリと CLI のソース |
+| [Python ドキュメント](../minipdf-python/README.md) | 実験版パッケージと CLI の使用方法 |
+| [Node.js ドキュメント](../minipdf-node/README.md) | 実験版ネイティブパッケージの使用方法 |
+| [Go ドキュメント](../minipdf-go/README.md) | 実験版パッケージと CLI の使用方法 |
 | [.NET XLSX ベンチマーク](../tests/MiniPdf.Benchmark/reports/comparison_report.md) | スプレッドシートの視覚比較結果 |
 | [.NET DOCX ベンチマーク](../tests/MiniPdf.Benchmark/reports_docx/comparison_report.md) | 文書の視覚比較結果 |
 | [Rust XLSX ベンチマーク](../artifacts/rust-benchmark/classic/xlsx/report/comparison_report.md) | Rust スプレッドシートの視覚比較結果 |

--- a/documents/README.ko.md
+++ b/documents/README.ko.md
@@ -2,11 +2,15 @@
 
 # MiniPdf
 
-**.NET 및 Rust용 경량 Office-to-PDF 라이브러리와 명령줄 도구입니다.**
+**.NET, Rust, Java, Python, Node.js 및 Go용 경량 Office-to-PDF 라이브러리와 명령줄 도구입니다.**
 
 <p>
 <a href="https://www.nuget.org/packages/MiniPdf"><img src="https://img.shields.io/nuget/v/MiniPdf.svg" alt="NuGet"></a>
 <a href="https://crates.io/crates/minipdf"><img src="https://img.shields.io/crates/v/minipdf.svg" alt="crates.io"></a>
+<a href="https://central.sonatype.com/artifact/io.github.shps951023/minipdf"><img src="https://img.shields.io/maven-central/v/io.github.shps951023/minipdf.svg" alt="Maven Central"></a>
+<a href="https://pypi.org/project/minipdf/"><img src="https://img.shields.io/pypi/v/minipdf.svg" alt="PyPI"></a>
+<a href="https://www.npmjs.com/package/minipdf"><img src="https://img.shields.io/npm/v/minipdf.svg" alt="npm"></a>
+<a href="https://pkg.go.dev/github.com/mini-software/MiniPdf/minipdf-go"><img src="https://pkg.go.dev/badge/github.com/mini-software/MiniPdf/minipdf-go.svg" alt="Go Reference"></a>
 <a href="https://github.com/mini-software/MiniPdf"><img src="https://img.shields.io/github/stars/mini-software/MiniPdf?logo=github" alt="GitHub stars"></a>
 <a href="https://doi.org/10.5281/zenodo.22057294"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.22057294.svg" alt="DOI"></a>
 <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
@@ -24,11 +28,14 @@ MiniPdf는 런타임에 Microsoft Office, LibreOffice, Adobe Acrobat 또는 COM 
 
 ## 구현 선택
 
-| | .NET | Rust |
-|---|---|---|
-| 입력 | XLSX, DOCX, PPTX | XLSX, DOCX |
-| 인터페이스 | .NET 라이브러리, CLI, 독립 실행형 Native AOT 바이너리 | Rust crate, CLI |
-| 문서 | **[.NET 가이드 열기](README.nuget.md)** | **[Rust 가이드 열기](../minipdf-rs/README.md)** |
+| 구현 | 입력 | 인터페이스 | 성숙도 | 문서 |
+|---|---|---|---|---|
+| .NET | XLSX, DOCX, PPTX | 라이브러리, CLI, Native AOT 바이너리 | 안정 | **[.NET 가이드](README.nuget.md)** |
+| Rust | XLSX, DOCX, PPTX | Crate, CLI | 실험적 | **[Rust 가이드](../minipdf-rs/README.md)** |
+| Java | XLSX, DOCX | 라이브러리, CLI | 실험적 | **[Java 소스](../minipdf-java/)** |
+| Python | DOCX | 패키지, CLI | 실험적 | **[Python 가이드](../minipdf-python/README.md)** |
+| Node.js | XLSX, DOCX, PPTX | 네이티브 패키지 | 실험적 | **[Node.js 가이드](../minipdf-node/README.md)** |
+| Go | XLSX, DOCX, PPTX | 패키지, CLI | 실험적 | **[Go 가이드](../minipdf-go/README.md)** |
 
 ## 빠른 시작
 
@@ -70,12 +77,74 @@ minipdf report.docx -o report.pdf
 
 [Rust 가이드](../minipdf-rs/README.md)에서는 crate API, CLI, 지원 범위, 알려진 제한 사항 및 개발 절차를 설명합니다.
 
+### Java
+
+```xml
+<dependency>
+	<groupId>io.github.shps951023</groupId>
+	<artifactId>minipdf</artifactId>
+	<version>0.1.0</version>
+</dependency>
+```
+
+```java
+import io.github.minisoftware.minipdf.MiniPdf;
+import java.nio.file.Path;
+
+MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
+```
+
+### Python
+
+```bash
+pip install minipdf
+```
+
+```python
+import minipdf
+
+minipdf.convert_to_pdf("report.docx", "report.pdf")
+```
+
+[Python 가이드](../minipdf-python/README.md)는 현재 DOCX 기능 범위와 CLI 옵션을 설명합니다.
+
+### Node.js
+
+```bash
+npm install minipdf
+```
+
+```javascript
+const minipdf = require('minipdf')
+
+minipdf.convertToPdf('report.docx', 'report.pdf')
+```
+
+[Node.js 가이드](../minipdf-node/README.md)는 메모리 내 변환, 페이지 크기, 글꼴 등록 및 지원 네이티브 플랫폼을 설명합니다.
+
+### Go
+
+```bash
+go get github.com/mini-software/MiniPdf/minipdf-go@latest
+```
+
+```go
+import minipdf "github.com/mini-software/MiniPdf/minipdf-go"
+
+if err := minipdf.ConvertToPDF("report.docx", "report.pdf"); err != nil {
+	panic(err)
+}
+```
+
+[Go 가이드](../minipdf-go/README.md)는 패키지, 네이티브 CLI, 현재 렌더링 범위 및 릴리스 태그를 설명합니다.
+
 ## MiniPdf를 선택하는 이유
 
 - **Office 제품군 불필요**: 애플리케이션 또는 CLI 내부에서 변환합니다.
 - **간결한 배포**: 의존성이 적고 외부 프로세스가 필요하지 않습니다.
 - **서버 및 CI 친화적**: 컨테이너, 클라우드 서비스 및 파이프라인에서 실행됩니다.
-- **네이티브 명령줄 옵션**: .NET Native AOT 릴리스와 Rust CLI를 제공합니다.
+- **다양한 언어 선택**: .NET, Rust, Java, Python, Node.js 또는 Go에서 MiniPdf를 사용할 수 있습니다.
+- **네이티브 명령줄 옵션**: .NET, Rust, Java, Python 및 Go에서 사용할 수 있습니다.
 
 MiniPdf는 실용적인 문서 변환을 목표로 하며 Microsoft Office 레이아웃을 완전히 재현하지는 않습니다. 복잡한 템플릿은 다르게 렌더링될 수 있으므로 온라인 데모나 벤치마크 보고서로 대표 파일을 평가하세요.
 
@@ -84,15 +153,16 @@ MiniPdf는 실용적인 문서 변환을 목표로 하며 Microsoft Office 레�
 GitHub Copilot, Claude Code, Cursor, Codex 또는 파일 편집과 PowerShell 실행이 가능한 모든 코딩 Agent에서 깨끗한 fork 또는 clone을 여세요. 가장 간단한 방법은 다음 지시문을 Agent 채팅에 붙여 넣는 것입니다.
 
 ```text
-Read CONTRIBUTING.md and run the MiniPdf contribution loop for dotnet from start to finish. Diagnose and improve the automatically selected benchmark cases, validate all changes, and prepare the pull request. Do not commit, push, fork, or open a pull request without my explicit approval.
+Read CONTRIBUTING.md and run the MiniPdf contribution loop from start to finish. Detect the installed supported language toolchains, randomly choose one available implementation, diagnose and improve the automatically selected benchmark cases, validate all changes, and prepare the pull request. Do not commit, push, fork, or open a pull request without my explicit approval.
 ```
 
-Rust 구현에 기여하려면 `dotnet`을 `rust`로 바꾸세요. 공통 PowerShell 진입점은 다음과 같습니다.
+공통 PowerShell 진입점은 `dotnet`과 `cargo`를 감지한 다음 설치된 구현 중 하나를 무작위로 선택합니다.
 
 ```powershell
-.\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start -Implementation dotnet
-.\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start -Implementation rust
+.\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start
 ```
+
+무작위 선택을 재정의하려면 `-Implementation dotnet` 또는 `-Implementation rust`를 전달하세요. 선택된 구현은 이후 모든 작업에서 사용할 수 있도록 이번 루프 상태에 저장됩니다.
 
 기여 루프는 도구 체인을 확인하고, 벤치마크 Python 패키지를 설치하고, 로컬 브랜치를 만든 뒤 선택한 렌더러에서 시각 점수가 가장 낮은 차이 두 건을 선택합니다. Agent는 사례별로 최대 세 번 수정하며 점수가 개선되지 않으면 자동으로 되돌리고 다음 사례로 이동합니다. 선택한 구현의 전체 테스트와 XLSX/DOCX 시각 벤치마크를 통과하고 의미 있는 회귀가 없을 때만 PR 생성을 허용합니다.
 
@@ -105,6 +175,10 @@ Rust 구현에 기여하려면 `dotnet`을 `rust`로 바꾸세요. 공통 PowerS
 | [온라인 데모](https://mini-software.github.io/MiniPdf/) | 브라우저에서 변환 체험 |
 | [.NET 문서](README.nuget.md) | 안정 버전 라이브러리 및 CLI 사용법 |
 | [Rust 문서](../minipdf-rs/README.md) | 실험 버전 crate 및 CLI 사용법 |
+| [Java 구현](../minipdf-java/) | 실험적 Maven 라이브러리 및 CLI 소스 |
+| [Python 문서](../minipdf-python/README.md) | 실험적 패키지 및 CLI 사용법 |
+| [Node.js 문서](../minipdf-node/README.md) | 실험적 네이티브 패키지 사용법 |
+| [Go 문서](../minipdf-go/README.md) | 실험적 패키지 및 CLI 사용법 |
 | [.NET XLSX 벤치마크](../tests/MiniPdf.Benchmark/reports/comparison_report.md) | 스프레드시트 시각 비교 결과 |
 | [.NET DOCX 벤치마크](../tests/MiniPdf.Benchmark/reports_docx/comparison_report.md) | 문서 시각 비교 결과 |
 | [Rust XLSX 벤치마크](../artifacts/rust-benchmark/classic/xlsx/report/comparison_report.md) | Rust 스프레드시트 시각 비교 결과 |

--- a/documents/README.zh-CN.md
+++ b/documents/README.zh-CN.md
@@ -2,11 +2,15 @@
 
 # MiniPdf
 
-**面向 .NET 与 Rust 的轻量级 Office 转 PDF 库和命令行工具。**
+**面向 .NET、Rust、Java、Python、Node.js 与 Go 的轻量级 Office 转 PDF 库和命令行工具。**
 
 <p>
 <a href="https://www.nuget.org/packages/MiniPdf"><img src="https://img.shields.io/nuget/v/MiniPdf.svg" alt="NuGet"></a>
 <a href="https://crates.io/crates/minipdf"><img src="https://img.shields.io/crates/v/minipdf.svg" alt="crates.io"></a>
+<a href="https://central.sonatype.com/artifact/io.github.shps951023/minipdf"><img src="https://img.shields.io/maven-central/v/io.github.shps951023/minipdf.svg" alt="Maven Central"></a>
+<a href="https://pypi.org/project/minipdf/"><img src="https://img.shields.io/pypi/v/minipdf.svg" alt="PyPI"></a>
+<a href="https://www.npmjs.com/package/minipdf"><img src="https://img.shields.io/npm/v/minipdf.svg" alt="npm"></a>
+<a href="https://pkg.go.dev/github.com/mini-software/MiniPdf/minipdf-go"><img src="https://pkg.go.dev/badge/github.com/mini-software/MiniPdf/minipdf-go.svg" alt="Go Reference"></a>
 <a href="https://github.com/mini-software/MiniPdf"><img src="https://img.shields.io/github/stars/mini-software/MiniPdf?logo=github" alt="GitHub stars"></a>
 <a href="https://doi.org/10.5281/zenodo.22057294"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.22057294.svg" alt="DOI"></a>
 <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
@@ -24,11 +28,14 @@ MiniPdf 无需在运行时安装 Microsoft Office、LibreOffice、Adobe Acrobat 
 
 ## 选择实现
 
-| | .NET | Rust |
-|---|---|---|
-| 输入 | XLSX、DOCX、PPTX | XLSX、DOCX |
-| 接口 | .NET 库、CLI、独立 Native AOT 二进制文件 | Rust crate、CLI |
-| 文档 | **[打开 .NET 指南](README.nuget.md)** | **[打开 Rust 指南](../minipdf-rs/README.md)** |
+| 实现 | 输入 | 接口 | 成熟度 | 文档 |
+|---|---|---|---|---|
+| .NET | XLSX、DOCX、PPTX | 库、CLI、Native AOT 二进制文件 | 稳定 | **[.NET 指南](README.nuget.md)** |
+| Rust | XLSX、DOCX、PPTX | Crate、CLI | 实验性 | **[Rust 指南](../minipdf-rs/README.md)** |
+| Java | XLSX、DOCX | 库、CLI | 实验性 | **[Java 源代码](../minipdf-java/)** |
+| Python | DOCX | 包、CLI | 实验性 | **[Python 指南](../minipdf-python/README.md)** |
+| Node.js | XLSX、DOCX、PPTX | 原生包 | 实验性 | **[Node.js 指南](../minipdf-node/README.md)** |
+| Go | XLSX、DOCX、PPTX | 包、CLI | 实验性 | **[Go 指南](../minipdf-go/README.md)** |
 
 ## 快速开始
 
@@ -70,12 +77,74 @@ minipdf report.docx -o report.pdf
 
 [Rust 指南](../minipdf-rs/README.md)介绍 crate API、CLI、支持范围、已知限制和开发流程。
 
+### Java
+
+```xml
+<dependency>
+	<groupId>io.github.shps951023</groupId>
+	<artifactId>minipdf</artifactId>
+	<version>0.1.0</version>
+</dependency>
+```
+
+```java
+import io.github.minisoftware.minipdf.MiniPdf;
+import java.nio.file.Path;
+
+MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
+```
+
+### Python
+
+```bash
+pip install minipdf
+```
+
+```python
+import minipdf
+
+minipdf.convert_to_pdf("report.docx", "report.pdf")
+```
+
+[Python 指南](../minipdf-python/README.md)列出了当前 DOCX 功能范围和 CLI 选项。
+
+### Node.js
+
+```bash
+npm install minipdf
+```
+
+```javascript
+const minipdf = require('minipdf')
+
+minipdf.convertToPdf('report.docx', 'report.pdf')
+```
+
+[Node.js 指南](../minipdf-node/README.md)涵盖内存转换、页面尺寸、字体注册和支持的原生平台。
+
+### Go
+
+```bash
+go get github.com/mini-software/MiniPdf/minipdf-go@latest
+```
+
+```go
+import minipdf "github.com/mini-software/MiniPdf/minipdf-go"
+
+if err := minipdf.ConvertToPDF("report.docx", "report.pdf"); err != nil {
+	panic(err)
+}
+```
+
+[Go 指南](../minipdf-go/README.md)介绍包、原生 CLI、当前渲染范围和发布标签。
+
 ## 为什么选择 MiniPdf
 
 - **无需 Office 套件**：转换直接在应用程序或 CLI 内运行。
 - **部署精简**：依赖少，无需外部进程。
 - **适合服务器与 CI**：可用于容器、云服务和流水线。
-- **原生命令行方案**：提供 .NET Native AOT 版本与 Rust CLI。
+- **多语言选择**：可从 .NET、Rust、Java、Python、Node.js 或 Go 使用 MiniPdf。
+- **原生命令行方案**：适用于 .NET、Rust、Java、Python 与 Go。
 
 MiniPdf 专注于实用文档转换，不追求完全复制 Microsoft Office 版式。复杂模板的渲染可能有所不同，请使用在线演示或基准报告评估代表性文件。
 
@@ -84,15 +153,16 @@ MiniPdf 专注于实用文档转换，不追求完全复制 Microsoft Office 版
 在 GitHub Copilot、Claude Code、Cursor、Codex，或任何可编辑文件并运行 PowerShell 的编码 Agent 中打开干净的 fork 或 clone。最简单的贡献方式是将以下指令粘贴到 Agent 聊天中：
 
 ```text
-Read CONTRIBUTING.md and run the MiniPdf contribution loop for dotnet from start to finish. Diagnose and improve the automatically selected benchmark cases, validate all changes, and prepare the pull request. Do not commit, push, fork, or open a pull request without my explicit approval.
+Read CONTRIBUTING.md and run the MiniPdf contribution loop from start to finish. Detect the installed supported language toolchains, randomly choose one available implementation, diagnose and improve the automatically selected benchmark cases, validate all changes, and prepare the pull request. Do not commit, push, fork, or open a pull request without my explicit approval.
 ```
 
-如需改进 Rust 实现，请将 `dotnet` 替换为 `rust`。通用 PowerShell 入口为：
+通用 PowerShell 入口会侦测 `dotnet` 与 `cargo`，然后从已安装的实现中随机选择一个：
 
 ```powershell
-.\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start -Implementation dotnet
-.\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start -Implementation rust
+.\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start
 ```
+
+如需覆盖随机选择，请传入 `-Implementation dotnet` 或 `-Implementation rust`。选定的实现会保存到本次循环的状态中，供后续所有操作使用。
 
 贡献循环会检查工具链、安装基准测试所需的 Python 包、创建本地分支，并自动挑选所选渲染器中视觉分数最低的两个差异。Agent 对每个案例最多尝试三次；分数没有改善时会自动还原，再继续下一个案例。只有所选实现的完整测试以及 XLSX/DOCX 视觉基准都通过，且没有明显回归时，才允许创建 PR。
 
@@ -105,6 +175,10 @@ Read CONTRIBUTING.md and run the MiniPdf contribution loop for dotnet from start
 | [在线演示](https://mini-software.github.io/MiniPdf/) | 在浏览器中试用转换 |
 | [.NET 文档](README.nuget.md) | 稳定版库与 CLI 用法 |
 | [Rust 文档](../minipdf-rs/README.md) | 实验版 crate 与 CLI 用法 |
+| [Java 实现](../minipdf-java/) | 实验性 Maven 库与 CLI 源代码 |
+| [Python 文档](../minipdf-python/README.md) | 实验性包与 CLI 用法 |
+| [Node.js 文档](../minipdf-node/README.md) | 实验性原生包用法 |
+| [Go 文档](../minipdf-go/README.md) | 实验性包与 CLI 用法 |
 | [.NET XLSX 基准](../tests/MiniPdf.Benchmark/reports/comparison_report.md) | 电子表格视觉比较结果 |
 | [.NET DOCX 基准](../tests/MiniPdf.Benchmark/reports_docx/comparison_report.md) | 文档视觉比较结果 |
 | [Rust XLSX 基准](../artifacts/rust-benchmark/classic/xlsx/report/comparison_report.md) | Rust 电子表格视觉比较结果 |

--- a/documents/README.zh-TW.md
+++ b/documents/README.zh-TW.md
@@ -2,11 +2,15 @@
 
 # MiniPdf
 
-**專為 .NET 與 Rust 打造的輕量級 Office 轉 PDF 程式庫與命令列工具。**
+**專為 .NET、Rust、Java、Python、Node.js 與 Go 打造的輕量級 Office 轉 PDF 程式庫與命令列工具。**
 
 <p>
 <a href="https://www.nuget.org/packages/MiniPdf"><img src="https://img.shields.io/nuget/v/MiniPdf.svg" alt="NuGet"></a>
 <a href="https://crates.io/crates/minipdf"><img src="https://img.shields.io/crates/v/minipdf.svg" alt="crates.io"></a>
+<a href="https://central.sonatype.com/artifact/io.github.shps951023/minipdf"><img src="https://img.shields.io/maven-central/v/io.github.shps951023/minipdf.svg" alt="Maven Central"></a>
+<a href="https://pypi.org/project/minipdf/"><img src="https://img.shields.io/pypi/v/minipdf.svg" alt="PyPI"></a>
+<a href="https://www.npmjs.com/package/minipdf"><img src="https://img.shields.io/npm/v/minipdf.svg" alt="npm"></a>
+<a href="https://pkg.go.dev/github.com/mini-software/MiniPdf/minipdf-go"><img src="https://pkg.go.dev/badge/github.com/mini-software/MiniPdf/minipdf-go.svg" alt="Go Reference"></a>
 <a href="https://github.com/mini-software/MiniPdf"><img src="https://img.shields.io/github/stars/mini-software/MiniPdf?logo=github" alt="GitHub stars"></a>
 <a href="https://doi.org/10.5281/zenodo.22057294"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.22057294.svg" alt="DOI"></a>
 <a href="../LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
@@ -24,11 +28,14 @@ MiniPdf 不需要在執行階段安裝 Microsoft Office、LibreOffice、Adobe Ac
 
 ## 選擇實作
 
-| | .NET | Rust |
-|---|---|---|
-| 輸入 | XLSX、DOCX、PPTX | XLSX、DOCX |
-| 介面 | .NET 程式庫、CLI、獨立 Native AOT 二進位檔 | Rust crate、CLI |
-| 文件 | **[開啟 .NET 指南](README.nuget.md)** | **[開啟 Rust 指南](../minipdf-rs/README.md)** |
+| 實作 | 輸入 | 介面 | 成熟度 | 文件 |
+|---|---|---|---|---|
+| .NET | XLSX、DOCX、PPTX | 程式庫、CLI、Native AOT 二進位檔 | 穩定 | **[.NET 指南](README.nuget.md)** |
+| Rust | XLSX、DOCX、PPTX | Crate、CLI | 實驗性 | **[Rust 指南](../minipdf-rs/README.md)** |
+| Java | XLSX、DOCX | 程式庫、CLI | 實驗性 | **[Java 原始碼](../minipdf-java/)** |
+| Python | DOCX | 套件、CLI | 實驗性 | **[Python 指南](../minipdf-python/README.md)** |
+| Node.js | XLSX、DOCX、PPTX | 原生套件 | 實驗性 | **[Node.js 指南](../minipdf-node/README.md)** |
+| Go | XLSX、DOCX、PPTX | 套件、CLI | 實驗性 | **[Go 指南](../minipdf-go/README.md)** |
 
 ## 快速開始
 
@@ -70,12 +77,74 @@ minipdf report.docx -o report.pdf
 
 [Rust 指南](../minipdf-rs/README.md)說明 crate API、CLI、支援範圍、已知限制與開發流程。
 
+### Java
+
+```xml
+<dependency>
+	<groupId>io.github.shps951023</groupId>
+	<artifactId>minipdf</artifactId>
+	<version>0.1.0</version>
+</dependency>
+```
+
+```java
+import io.github.minisoftware.minipdf.MiniPdf;
+import java.nio.file.Path;
+
+MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
+```
+
+### Python
+
+```bash
+pip install minipdf
+```
+
+```python
+import minipdf
+
+minipdf.convert_to_pdf("report.docx", "report.pdf")
+```
+
+[Python 指南](../minipdf-python/README.md)列出目前的 DOCX 功能範圍與 CLI 選項。
+
+### Node.js
+
+```bash
+npm install minipdf
+```
+
+```javascript
+const minipdf = require('minipdf')
+
+minipdf.convertToPdf('report.docx', 'report.pdf')
+```
+
+[Node.js 指南](../minipdf-node/README.md)涵蓋記憶體內轉換、頁面尺寸、字型註冊與支援的原生平台。
+
+### Go
+
+```bash
+go get github.com/mini-software/MiniPdf/minipdf-go@latest
+```
+
+```go
+import minipdf "github.com/mini-software/MiniPdf/minipdf-go"
+
+if err := minipdf.ConvertToPDF("report.docx", "report.pdf"); err != nil {
+	panic(err)
+}
+```
+
+[Go 指南](../minipdf-go/README.md)說明套件、原生 CLI、目前的呈現範圍與發布標籤。
+
 ## 為什麼選擇 MiniPdf
 
 - **不需要 Office 套件**：轉換直接在應用程式或 CLI 內執行。
 - **精簡部署**：相依套件少，不需要外部程序。
 - **適合伺服器與 CI**：可用於容器、雲端服務與工作流程。
-- **原生命令列選項**：提供 .NET Native AOT 版本與 Rust CLI。
+- **多語言選擇**：可從 .NET、Rust、Java、Python、Node.js 或 Go 使用 MiniPdf。
+- **原生命令列選項**：適用於 .NET、Rust、Java、Python 與 Go。
 
 MiniPdf 專注於實用文件轉換，不追求完整複製 Microsoft Office 版面。複雜範本的呈現可能不同，請使用線上展示或基準報告評估代表性檔案。
 
@@ -84,15 +153,16 @@ MiniPdf 專注於實用文件轉換，不追求完整複製 Microsoft Office 版
 在 GitHub Copilot、Claude Code、Cursor、Codex，或任何可編輯檔案並執行 PowerShell 的程式設計 Agent 中開啟乾淨的 fork 或 clone。最簡單的貢獻方式是將以下指令貼到 Agent 聊天中：
 
 ```text
-Read CONTRIBUTING.md and run the MiniPdf contribution loop for dotnet from start to finish. Diagnose and improve the automatically selected benchmark cases, validate all changes, and prepare the pull request. Do not commit, push, fork, or open a pull request without my explicit approval.
+Read CONTRIBUTING.md and run the MiniPdf contribution loop from start to finish. Detect the installed supported language toolchains, randomly choose one available implementation, diagnose and improve the automatically selected benchmark cases, validate all changes, and prepare the pull request. Do not commit, push, fork, or open a pull request without my explicit approval.
 ```
 
-如要改善 Rust 實作，請將 `dotnet` 替換為 `rust`。通用 PowerShell 入口為：
+通用 PowerShell 入口會偵測 `dotnet` 與 `cargo`，再從已安裝的實作中隨機選擇一個：
 
 ```powershell
-.\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start -Implementation dotnet
-.\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start -Implementation rust
+.\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start
 ```
+
+如需覆寫隨機選擇，請傳入 `-Implementation dotnet` 或 `-Implementation rust`。選定的實作會儲存在本次循環的狀態中，供後續所有操作使用。
 
 貢獻循環會檢查工具鏈、安裝基準測試所需的 Python 套件、建立本機分支，並自動挑選所選渲染器中視覺分數最低的兩個差異。Agent 對每個案例最多嘗試三次；分數沒有改善時會自動還原，再繼續下一個案例。只有所選實作的完整測試及 XLSX/DOCX 視覺基準都通過，且沒有明顯退步時，才允許建立 PR。
 
@@ -105,6 +175,10 @@ Read CONTRIBUTING.md and run the MiniPdf contribution loop for dotnet from start
 | [線上展示](https://mini-software.github.io/MiniPdf/) | 在瀏覽器中試用轉換 |
 | [.NET 文件](README.nuget.md) | 穩定版程式庫與 CLI 用法 |
 | [Rust 文件](../minipdf-rs/README.md) | 實驗版 crate 與 CLI 用法 |
+| [Java 實作](../minipdf-java/) | 實驗性 Maven 程式庫與 CLI 原始碼 |
+| [Python 文件](../minipdf-python/README.md) | 實驗性套件與 CLI 用法 |
+| [Node.js 文件](../minipdf-node/README.md) | 實驗性原生套件用法 |
+| [Go 文件](../minipdf-go/README.md) | 實驗性套件與 CLI 用法 |
 | [.NET XLSX 基準](../tests/MiniPdf.Benchmark/reports/comparison_report.md) | 試算表視覺比較結果 |
 | [.NET DOCX 基準](../tests/MiniPdf.Benchmark/reports_docx/comparison_report.md) | 文件視覺比較結果 |
 | [Rust XLSX 基準](../artifacts/rust-benchmark/classic/xlsx/report/comparison_report.md) | Rust 試算表視覺比較結果 |

--- a/minipdf-node/index.js
+++ b/minipdf-node/index.js
@@ -59,7 +59,7 @@ switch (platform) {
           if (localFileExisted) {
             nativeBinding = require('./minipdf-node.win32-x64-msvc.node')
           } else {
-            nativeBinding = require('minipdf-win32-x64-msvc')
+            nativeBinding = require('@mini-software/minipdf-win32-x64-msvc')
           }
         } catch (e) {
           loadError = e

--- a/minipdf-node/scripts/postprocess-loader.js
+++ b/minipdf-node/scripts/postprocess-loader.js
@@ -3,6 +3,8 @@
 const fs = require('node:fs')
 const path = require('node:path')
 
+const oldWindowsX64Require = "require('minipdf-win32-x64-msvc')"
+const newWindowsX64Require = "require('@mini-software/minipdf-win32-x64-msvc')"
 const oldMuslFunction = /function isMusl\(\) \{[\s\S]*?\n\}\n\nswitch \(platform\)/
 const newMuslFunction = `function isMusl() {
   const { glibcVersionRuntime } = process.report.getReport().header
@@ -27,10 +29,11 @@ const newLoadFailure = `if (!nativeBinding) {
 }`
 
 function postprocessLoader(source) {
-  let output = source.replace(
+  let output = source.replaceAll('\r\n', '\n').replace(
     "const { existsSync, readFileSync } = require('fs')",
     "const { existsSync } = require('fs')"
   )
+  output = output.replaceAll(oldWindowsX64Require, newWindowsX64Require)
 
   if (!output.includes(newMuslFunction)) {
     output = output.replace(oldMuslFunction, newMuslFunction)
@@ -39,7 +42,11 @@ function postprocessLoader(source) {
     output = output.replace(oldLoadFailure, newLoadFailure)
   }
 
-  if (!output.includes(newMuslFunction) || !output.includes(newLoadFailure)) {
+  if (
+    !output.includes(newWindowsX64Require) ||
+    !output.includes(newMuslFunction) ||
+    !output.includes(newLoadFailure)
+  ) {
     throw new Error('Generated N-API loader did not match the expected structure')
   }
 

--- a/minipdf-node/scripts/prepare-release.js
+++ b/minipdf-node/scripts/prepare-release.js
@@ -2,6 +2,7 @@
 
 const fs = require('node:fs')
 const path = require('node:path')
+const { postprocessLoader } = require('./postprocess-loader.js')
 
 const SUPPORTED_NATIVE_PACKAGES = [
   'minipdf-darwin-arm64',
@@ -13,6 +14,10 @@ const SUPPORTED_NATIVE_PACKAGES = [
   'minipdf-win32-arm64-msvc',
   'minipdf-win32-x64-msvc'
 ]
+
+const PUBLISHED_PACKAGE_NAMES = {
+  'minipdf-win32-x64-msvc': '@mini-software/minipdf-win32-x64-msvc'
+}
 
 function prepareRelease(packageRoot = process.cwd()) {
   const packagePath = path.join(packageRoot, 'package.json')
@@ -43,17 +48,39 @@ function prepareRelease(packageRoot = process.cwd()) {
       )
     }
 
+    const generatedName = platformPackage.name
+    platformPackage.name = PUBLISHED_PACKAGE_NAMES[generatedName] || generatedName
+    fs.writeFileSync(
+      path.join(platformDirectory, 'package.json'),
+      `${JSON.stringify(platformPackage, null, 2)}\n`
+    )
+
+    const readmePath = path.join(platformDirectory, 'README.md')
+    if (platformPackage.name !== generatedName && fs.existsSync(readmePath)) {
+      const readme = fs.readFileSync(readmePath, 'utf8')
+      fs.writeFileSync(readmePath, readme.replaceAll(generatedName, platformPackage.name))
+    }
+
     optionalDependencies[platformPackage.name] = platformPackage.version
     fs.copyFileSync(licensePath, path.join(platformDirectory, 'LICENSE'))
   }
 
   const nativePackageNames = Object.keys(optionalDependencies).sort()
-  if (!SUPPORTED_NATIVE_PACKAGES.every((name, index) => name === nativePackageNames[index])) {
+  const publishedPackageNames = SUPPORTED_NATIVE_PACKAGES
+    .map((name) => PUBLISHED_PACKAGE_NAMES[name] || name)
+    .sort()
+  if (!publishedPackageNames.every((name, index) => name === nativePackageNames[index])) {
     throw new Error(`Unexpected platform package set: ${nativePackageNames.join(', ')}`)
   }
 
   packageJson.optionalDependencies = optionalDependencies
   fs.writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`)
+
+  const loaderPath = path.join(packageRoot, 'index.js')
+  if (fs.existsSync(loaderPath)) {
+    const loader = fs.readFileSync(loaderPath, 'utf8')
+    fs.writeFileSync(loaderPath, postprocessLoader(loader))
+  }
 
   return optionalDependencies
 }

--- a/minipdf-node/test/index.test.js
+++ b/minipdf-node/test/index.test.js
@@ -11,7 +11,7 @@ const packageJson = require('../package.json')
 const { postprocessLoader } = require('../scripts/postprocess-loader.js')
 const { prepareRelease } = require('../scripts/prepare-release.js')
 
-const expectedNativePackages = [
+const generatedNativePackages = [
   'minipdf-darwin-arm64',
   'minipdf-darwin-x64',
   'minipdf-linux-arm64-gnu',
@@ -21,6 +21,12 @@ const expectedNativePackages = [
   'minipdf-win32-arm64-msvc',
   'minipdf-win32-x64-msvc'
 ]
+
+const expectedNativePackages = generatedNativePackages.map((name) =>
+  name === 'minipdf-win32-x64-msvc'
+    ? '@mini-software/minipdf-win32-x64-msvc'
+    : name
+)
 
 const fixturePath = path.join(
   __dirname,
@@ -88,6 +94,8 @@ test('keeps native loader diagnostics compatible with Node 18', () => {
   const loader = fs.readFileSync(loaderPath, 'utf8')
 
   assert.doesNotMatch(loader, /which ldd|readFileSync/)
+  assert.doesNotMatch(loader, /require\('minipdf-win32-x64-msvc'\)/)
+  assert.match(loader, /require\('@mini-software\/minipdf-win32-x64-msvc'\)/)
   assert.match(loader, /Failed to load MiniPdf native binding for \$\{platform\}\/\$\{arch\}/)
   assert.equal(postprocessLoader(loader), loader)
 })
@@ -101,8 +109,9 @@ test('prepares aligned platform packages for release', (context) => {
     JSON.stringify({ name: 'minipdf', version: '0.1.0' })
   )
   fs.writeFileSync(path.join(packageRoot, 'LICENSE'), 'license text')
+  fs.copyFileSync(path.join(__dirname, '..', 'index.js'), path.join(packageRoot, 'index.js'))
 
-  for (const packageName of expectedNativePackages) {
+  for (const packageName of generatedNativePackages) {
     const platformDirectory = path.join(
       packageRoot,
       'npm',
@@ -125,6 +134,14 @@ test('prepares aligned platform packages for release', (context) => {
   )
   assert.deepEqual(dependencies, expectedDependencies)
   assert.deepEqual(preparedPackage.optionalDependencies, expectedDependencies)
+  const windowsX64Package = JSON.parse(
+    fs.readFileSync(path.join(packageRoot, 'npm', 'win32-x64-msvc', 'package.json'), 'utf8')
+  )
+  assert.equal(windowsX64Package.name, '@mini-software/minipdf-win32-x64-msvc')
+  assert.match(
+    fs.readFileSync(path.join(packageRoot, 'index.js'), 'utf8'),
+    /require\('@mini-software\/minipdf-win32-x64-msvc'\)/
+  )
   assert.equal(
     fs.readFileSync(path.join(packageRoot, 'npm', 'darwin-arm64', 'LICENSE'), 'utf8'),
     'license text'

--- a/scripts/Invoke-MiniPdfContributionLoop.ps1
+++ b/scripts/Invoke-MiniPdfContributionLoop.ps1
@@ -3,10 +3,10 @@
     Run the MiniPdf contribution loop from any coding agent or terminal.
 
 .EXAMPLE
-    .\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start -Implementation dotnet
+    .\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start
 
 .EXAMPLE
-    .\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start -Implementation rust
+    .\scripts\Invoke-MiniPdfContributionLoop.ps1 -Action Start -Implementation dotnet
 #>
 
 [CmdletBinding()]
@@ -14,8 +14,8 @@ param(
     [Parameter(Mandatory)]
     [ValidateSet("Start", "Begin", "Evaluate", "Validate", "Pr", "Status")]
     [string]$Action,
-    [ValidateSet("dotnet", "rust")]
-    [string]$Implementation = "dotnet",
+    [ValidateSet("auto", "dotnet", "rust")]
+    [string]$Implementation = "auto",
     [ValidateSet("xlsx", "docx")]
     [string]$Format,
     [string]$CaseName,


### PR DESCRIPTION
## Summary

- publish the spam-blocked Windows x64 native package as `@mini-software/minipdf-win32-x64-msvc` while preserving `npm install minipdf`
- rewrite the generated loader and release metadata consistently after N-API package generation
- add automatic detection and random selection of installed .NET/Rust toolchains to the contribution loop
- document Java, Python, Node.js, and Go badges and usage across the English README and six translations

## Why

npm rejected `minipdf-win32-x64-msvc` with `E403 Package name triggered spam detection`. Because initial publication processes platform packages first, that rejection prevented the workflow from reaching the top-level `minipdf` package.

## Validation

- `npm test` (8 passed)
- `npm pack . --dry-run --ignore-scripts`
- scoped release fixture validation
- PowerShell parser and automatic toolchain-selection behavior checks
- README fence, relative-link, and synchronized-content checks
- `git diff --check`

Two unrelated Rust working-tree changes were intentionally excluded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Java, Python, Node.js, and Go implementations, including quick-start guidance and documentation.
  * Contribution workflows now automatically detect available .NET and Rust toolchains and select an implementation, while allowing explicit overrides.

* **Bug Fixes**
  * Updated Windows x64 Node.js package loading to use the scoped native package.
  * Improved release packaging validation and loader error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->