### PR TITLE
Fix Blazor converter stuck on Loading

### DIFF
--- a/MiniPdf.Web/MiniPdf.Web.Client/Program.cs
+++ b/MiniPdf.Web/MiniPdf.Web.Client/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.JSInterop;
 using MiniPdf.Web.Client;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
+builder.RootComponents.Add<App>("#app");
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 builder.Services.AddSingleton<I18n>();


### PR DESCRIPTION
## Summary

- restore the standalone Blazor WebAssembly root component registration
- mount `App` into `#app` so the converter replaces the static Loading placeholder

## Validation

- `dotnet publish MiniPdf.Web/MiniPdf.Web.Client/MiniPdf.Web.Client.csproj -c Release`
- verified the published app renders the full converter UI in a browser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The web application now correctly loads and displays its main application component, improving startup and rendering reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->