### PR TITLE
Use tracked fixtures in Java release tests

### DIFF
--- a/minipdf-java/minipdf-cli/src/test/java/io/github/minisoftware/minipdf/cli/MiniPdfCommandTest.java
+++ b/minipdf-java/minipdf-cli/src/test/java/io/github/minisoftware/minipdf/cli/MiniPdfCommandTest.java
@@ -21,8 +21,7 @@ class MiniPdfCommandTest {
 
     @Test
     void convertsXlsxWithDirectSyntax() throws Exception {
-        Path source = REPOSITORY_ROOT.resolve(
-                "tests/MiniPdf.Scripts/output/classic01_basic_table_with_headers.xlsx");
+                Path source = REPOSITORY_ROOT.resolve("tests/Issue_Files/xlsx/Simple invoice1.xlsx");
         Path output = temporaryDirectory.resolve("direct.pdf");
 
         CommandResult result = execute(source.toString(), "-o", output.toString());
@@ -34,8 +33,7 @@ class MiniPdfCommandTest {
 
     @Test
     void convertsDocxWithSubcommandAndCustomSize() throws Exception {
-        Path source = REPOSITORY_ROOT.resolve(
-                "tests/MiniPdf.Scripts/output_docx/docx_classic01_single_paragraph.docx");
+                Path source = REPOSITORY_ROOT.resolve("tests/Issue_Files/docx/Invoice.docx");
         Path output = temporaryDirectory.resolve("subcommand.pdf");
 
         CommandResult result = execute(
@@ -61,8 +59,7 @@ class MiniPdfCommandTest {
 
     @Test
     void rejectsConflictingPageOptions() {
-        Path source = REPOSITORY_ROOT.resolve(
-                "tests/MiniPdf.Scripts/output/classic01_basic_table_with_headers.xlsx");
+                Path source = REPOSITORY_ROOT.resolve("tests/Issue_Files/xlsx/Simple invoice1.xlsx");
 
         CommandResult result = execute(
                 source.toString(), "--paper-size", "a4", "--page-width", "400", "--page-height", "500");

--- a/minipdf-java/minipdf/src/test/java/io/github/minisoftware/minipdf/ClassicFixtureSmokeTest.java
+++ b/minipdf-java/minipdf/src/test/java/io/github/minisoftware/minipdf/ClassicFixtureSmokeTest.java
@@ -12,27 +12,24 @@ class ClassicFixtureSmokeTest {
     private static final Path REPOSITORY_ROOT = Path.of("..", "..").toAbsolutePath().normalize();
 
     @Test
-    void convertsClassic01Xlsx() throws Exception {
-        Path fixture = REPOSITORY_ROOT.resolve(
-                "tests/MiniPdf.Scripts/output/classic01_basic_table_with_headers.xlsx");
+    void convertsTrackedXlsxFixture() throws Exception {
+        Path fixture = REPOSITORY_ROOT.resolve("tests/Issue_Files/xlsx/Simple invoice1.xlsx");
 
         String pdf = pdfText(MiniPdf.convertToPdfBytes(fixture));
 
-        assertTrue(pdf.contains("(Name    Age    City) Tj"));
-        assertTrue(pdf.contains("(Alice    30    New York) Tj"));
+        assertTrue(pdf.contains("INVOICE"));
+        assertTrue(pdf.contains("Wedding florals"));
         assertTrue(pdf.endsWith("%%EOF\n"));
     }
 
     @Test
-    void convertsClassic01Docx() throws Exception {
-        Path fixture = REPOSITORY_ROOT.resolve(
-                "tests/MiniPdf.Scripts/output_docx/docx_classic01_single_paragraph.docx");
+    void convertsTrackedDocxFixture() throws Exception {
+        Path fixture = REPOSITORY_ROOT.resolve("tests/Issue_Files/docx/Invoice.docx");
 
         String pdf = pdfText(MiniPdf.convertToPdfBytes(fixture));
 
-        assertTrue(pdf.contains("Hello, World!"));
-        assertTrue(pdf.contains("benchmarking"));
-        assertTrue(pdf.contains("MiniPdf DOCX-to-PDF conversion."));
+        assertTrue(pdf.contains("Invoice"));
+        assertTrue(pdf.contains("ABC12345"));
         assertTrue(pdf.endsWith("%%EOF\n"));
     }
 


### PR DESCRIPTION
## Summary

- use Git-tracked shared XLSX and DOCX fixtures in Java library smoke tests
- use the same tracked fixtures in Java CLI tests
- make Maven release builds reproducible from a clean clone

## Validation

- focused tracked-fixture test: 3 passed
- Java Maven reactor: 33 tests passed
- `git diff --check` passed