### PR TITLE
Fix VML style parsing on netstandard2.0

### DIFF
--- a/src/MiniPdf/ExcelReader.cs
+++ b/src/MiniPdf/ExcelReader.cs
@@ -3748,7 +3748,7 @@ internal static class ExcelReader
     {
         foreach (var declaration in style.Split(';'))
         {
-            var parts = declaration.Split(':', 2);
+            var parts = declaration.Split(new[] { ':' }, 2);
             if (parts.Length != 2 || !string.Equals(parts[0].Trim(), property, StringComparison.OrdinalIgnoreCase))
                 continue;
             var value = parts[1].Trim();


### PR DESCRIPTION
## Summary
- use the `string.Split(char[], int)` overload supported by `netstandard2.0`
- preserve the existing two-part VML style parsing behavior
- unblock NuGet packaging after the initial `v0.41.0` run failed during build

## Validation
- `dotnet build src/MiniPdf/MiniPdf.csproj -c Release --no-restore`
- `dotnet test tests/MiniPdf.Tests/MiniPdf.Tests.csproj -c Release --no-restore` (185 passed)

Failed release run: https://github.com/mini-software/MiniPdf/actions/runs/33874247411

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal style parsing without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->