### PR TITLE
fix: keep oversized inline image on one page in DOCX rendering

### DIFF
--- a/src/MiniPdf/DocxToPdfConverter.cs
+++ b/src/MiniPdf/DocxToPdfConverter.cs
@@ -3362,15 +3362,20 @@ internal static class DocxToPdfConverter
             height *= scale;
         }
 
-        // Move the whole image to the next page when it does not fit in the
-        // remaining space. Word keeps an inline image on a single page rather
-        // than clipping it at the page bottom. EnsurePage only adds a page once
-        // the cursor is already past the bottom margin, which leaves a partial
-        // image clipped, so force the break here instead. Skip when already at
-        // the top of a fresh page, otherwise an image taller than the usable
-        // area would push out a blank page ahead of it (Word overflows there).
+        // Move the whole image to the next column/page when it does not fit in
+        // the remaining space. Word keeps an inline image intact rather than
+        // clipping it at the bottom. EnsurePage only adds a page once the cursor
+        // is already past the bottom margin, which leaves a partial image
+        // clipped, so handle the break here. In a multi-column section flow to
+        // the next column first (as EnsurePage does); only force a new page when
+        // no column remains. Skip entirely when already at the top of a fresh
+        // column/page, otherwise an image taller than the usable area would push
+        // out a blank column/page ahead of it (Word overflows there).
         if (state.CurrentY - height < state.Options.MarginBottom && !state.IsTopOfPage)
-            state.ForceNewPage();
+        {
+            if (!(state.ColumnCount > 1 && state.AdvanceToNextColumn()))
+                state.ForceNewPage();
+        }
 
         var x = state.Options.MarginLeft;
         if (image.IsWrapTopBottom)

--- a/src/MiniPdf/DocxToPdfConverter.cs
+++ b/src/MiniPdf/DocxToPdfConverter.cs
@@ -3362,9 +3362,15 @@ internal static class DocxToPdfConverter
             height *= scale;
         }
 
-        // Check if image fits on current page
-        if (state.CurrentY - height < state.Options.MarginBottom)
-            state.EnsurePage();
+        // Move the whole image to the next page when it does not fit in the
+        // remaining space. Word keeps an inline image on a single page rather
+        // than clipping it at the page bottom. EnsurePage only adds a page once
+        // the cursor is already past the bottom margin, which leaves a partial
+        // image clipped, so force the break here instead. Skip when already at
+        // the top of a fresh page, otherwise an image taller than the usable
+        // area would push out a blank page ahead of it (Word overflows there).
+        if (state.CurrentY - height < state.Options.MarginBottom && !state.IsTopOfPage)
+            state.ForceNewPage();
 
         var x = state.Options.MarginLeft;
         if (image.IsWrapTopBottom)

--- a/tests/MiniPdf.Tests/DocxToPdfConverterTests.cs
+++ b/tests/MiniPdf.Tests/DocxToPdfConverterTests.cs
@@ -274,6 +274,44 @@ public class DocxToPdfConverterTests
         Assert.Contains(doc.Pages, page => page.ImageBlocks.Count > 0);
     }
 
+    [Fact]
+    public void Convert_InlineImageThatDoesNotFit_MovesToNextPageWithoutClipping()
+    {
+        // Small page so a few filler lines plus a moderate image cannot share one page.
+        var options = new DocxToPdfConverter.ConversionOptions
+        {
+            PageWidth = 400,
+            PageHeight = 400,
+            MarginTop = 40,
+            MarginBottom = 40,
+            MarginLeft = 40,
+            MarginRight = 40,
+        };
+        // ~260pt image: fits on a fresh page (usable height 320) but not once the
+        // filler lines have consumed most of page 1.
+        const long imageEmu = 260L * 12700L;
+        using var docxStream = CreateDocxWithFillerThenTallImage(
+            fillerParagraphs: 10, imageCxEmu: imageEmu, imageCyEmu: imageEmu);
+
+        var doc = DocxToPdfConverter.Convert(docxStream, options);
+
+        var placed = doc.Pages
+            .Select((page, index) => (page, index))
+            .SelectMany(entry => entry.page.ImageBlocks.Select(block => (entry.index, block)))
+            .ToList();
+        Assert.Single(placed);
+        var (pageIndex, image) = placed[0];
+
+        // The whole image must move to a later page rather than being clipped at the
+        // bottom of page 1 (the behavior this fix restores).
+        Assert.True(pageIndex >= 1, $"Expected the image on a page after the first; got page {pageIndex + 1}.");
+        // And it must sit fully inside the printable area, not off the bottom edge.
+        Assert.True(image.Y >= options.MarginBottom,
+            $"Image bottom {image.Y} is below the bottom margin {options.MarginBottom} (clipped).");
+        Assert.True(image.Y + image.RenderHeight <= options.PageHeight - options.MarginTop + 0.5f,
+            $"Image top {image.Y + image.RenderHeight} exceeds the printable area.");
+    }
+
     private static void AssertXrefOffsetsAreCorrect(byte[] pdfBytes)
     {
         var text = Encoding.GetEncoding("iso-8859-1").GetString(pdfBytes);
@@ -400,6 +438,103 @@ public class DocxToPdfConverterTests
 
             // Add the PNG image as binary entry
             var imgEntry = archive.CreateEntry(imageEntryPath);
+            using (var imgStream = imgEntry.Open())
+                imgStream.Write(pngBytes, 0, pngBytes.Length);
+        }
+
+        ms.Position = 0;
+        return ms;
+    }
+
+    /// <summary>
+    /// Builds a DOCX with a run of filler paragraphs followed by a single inline
+    /// image of the given EMU size, used to exercise page-break handling when the
+    /// image cannot fit in the remaining space on the current page.
+    /// </summary>
+    private static MemoryStream CreateDocxWithFillerThenTallImage(
+        int fillerParagraphs, long imageCxEmu, long imageCyEmu)
+    {
+        var ms = new MemoryStream();
+        var pngBytes = CreateMinimalRgbaPng(4, 4);
+
+        var filler = string.Concat(Enumerable.Range(0, fillerParagraphs)
+            .Select(i => $"<w:p><w:r><w:t>Filler line {i}</w:t></w:r></w:p>"));
+
+        using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            AddEntry(archive, "[Content_Types].xml",
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+                  <Default Extension="xml" ContentType="application/xml"/>
+                  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+                  <Default Extension="png" ContentType="image/png"/>
+                  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+                </Types>
+                """);
+
+            AddEntry(archive, "_rels/.rels",
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+                  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+                </Relationships>
+                """);
+
+            AddEntry(archive, "word/_rels/document.xml.rels",
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+                  <Relationship Id="rId10" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png"/>
+                </Relationships>
+                """);
+
+            AddEntry(archive, "word/document.xml",
+                $$"""
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+                            xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+                            xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+                            xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+                            xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+                  <w:body>
+                    {{filler}}
+                    <w:p>
+                      <w:r>
+                        <w:drawing>
+                          <wp:inline distT="0" distB="0" distL="0" distR="0">
+                            <wp:extent cx="{{imageCxEmu}}" cy="{{imageCyEmu}}"/>
+                            <wp:docPr id="1" name="Picture 1"/>
+                            <a:graphic>
+                              <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+                                <pic:pic>
+                                  <pic:nvPicPr>
+                                    <pic:cNvPr id="1" name="image1.png"/>
+                                    <pic:cNvPicPr/>
+                                  </pic:nvPicPr>
+                                  <pic:blipFill>
+                                    <a:blip r:embed="rId10"/>
+                                    <a:stretch><a:fillRect/></a:stretch>
+                                  </pic:blipFill>
+                                  <pic:spPr>
+                                    <a:xfrm>
+                                      <a:off x="0" y="0"/>
+                                      <a:ext cx="{{imageCxEmu}}" cy="{{imageCyEmu}}"/>
+                                    </a:xfrm>
+                                    <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+                                  </pic:spPr>
+                                </pic:pic>
+                              </a:graphicData>
+                            </a:graphic>
+                          </wp:inline>
+                        </w:drawing>
+                      </w:r>
+                    </w:p>
+                  </w:body>
+                </w:document>
+                """);
+
+            var imgEntry = archive.CreateEntry("word/media/image1.png");
             using (var imgStream = imgEntry.Open())
                 imgStream.Write(pngBytes, 0, pngBytes.Length);
         }


### PR DESCRIPTION
## Problem & intended behavior

When a DOCX inline image does not fit in the remaining space on the current
page, MiniPdf drew it at the current cursor and let the page boundary clip it,
so the image was lost and the next page began with only the following content.
Word and LibreOffice keep the image whole by moving it to the next page.

Intended behavior: an inline image that would cross the bottom margin is moved
in its entirety to the next page.

Root cause: `RenderImage` called `EnsurePage()`, whose guard only adds a page
once the cursor is already past the bottom margin. In the "image would cross
the margin" case the cursor is still on the page, so no page was added and the
image overflowed off the bottom edge.

## Linked issues / discussion

N/A — isolated rendering fix, no API/architecture change.

## Change

- `src/MiniPdf/DocxToPdfConverter.cs`: force a page break when the image would
  cross the bottom margin so the whole image moves to the next page; skip when
  already at the top of a fresh page so an image taller than the usable area
  still overflows instead of emitting a blank page ahead of it.
- `tests/MiniPdf.Tests/DocxToPdfConverterTests.cs`: add a regression test.

## Tests & validation commands

- `dotnet test tests/MiniPdf.Tests --configuration Release` — 186/186 passing,
  including the new `Convert_InlineImageThatDoesNotFit_MovesToNextPageWithoutClipping`
  (fails against the pre-fix `EnsurePage()` behavior, passes with the fix).
- `scripts/Run-Benchmark_docx.ps1 -Filter "classic30"` (focused DOCX visual) — improved
- `scripts/Run-Benchmark_docx.ps1` (full DOCX visual gate) — no regressions
- `scripts/Run-Benchmark.ps1` (full XLSX visual gate) — no regressions
- `git diff --check` — clean

## Before/after evidence (rendering change)

Benchmark score (docx, LibreOffice reference):

| Case | Before overall | After overall | Before visual | After visual | Pages cand/ref |
| --- | ---: | ---: | ---: | ---: | ---: |
| docx_classic30_comprehensive_report | 0.9086 | 0.9888 | 0.7759 | 0.9765 | 3/3 |

Reproduced with the published `MiniPdf 0.41.1` NuGet package (before) vs. this
branch (after). Pages 2–3 shown below — page 2 = image clipped and lost at the
page bottom; page 3 = image correctly moved to the next page, matching the
LibreOffice reference:

<img width="1916" height="2504" alt="classic30_before_after" src="https://github.com/user-attachments/assets/60940969-4f0b-4679-a6a3-8505f9aa3787" />

## Public API / compatibility impact

None. No public API change; behavior is unchanged for images that already fit.
Only the doesn't-fit-and-not-top-of-page path is affected.

## Third-party material

None added.

## Documentation

No user-visible API/CLI change; no documentation updates required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Inline images that do not fit in the remaining space now move to the next available column or page without being clipped.
  * Prevented unnecessary blank pages when an oversized image begins on a fresh column or page.

* **Tests**
  * Added coverage verifying that tall inline images remain fully within the printable area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->