### PR TITLE
Release Java 0.1.2 under MiniSoftware namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p>
 <a href="https://www.nuget.org/packages/MiniPdf"><img src="https://img.shields.io/nuget/v/MiniPdf.svg" alt="NuGet"></a>
 <a href="https://crates.io/crates/minipdf"><img src="https://img.shields.io/crates/v/minipdf.svg" alt="crates.io"></a>
-<a href="https://central.sonatype.com/artifact/io.github.shps951023/minipdf"><img src="https://img.shields.io/maven-central/v/io.github.shps951023/minipdf.svg" alt="Maven Central"></a>
+<a href="https://central.sonatype.com/artifact/io.github.mini-software/minipdf"><img src="https://img.shields.io/maven-central/v/io.github.mini-software/minipdf.svg" alt="Maven Central"></a>
 <a href="https://pypi.org/project/minipdf/"><img src="https://img.shields.io/pypi/v/minipdf.svg" alt="PyPI"></a>
 <a href="https://www.npmjs.com/package/minipdf"><img src="https://img.shields.io/npm/v/minipdf.svg" alt="npm"></a>
 <a href="https://pkg.go.dev/github.com/mini-software/MiniPdf/minipdf-go"><img src="https://pkg.go.dev/badge/github.com/mini-software/MiniPdf/minipdf-go.svg" alt="Go Reference"></a>
@@ -87,11 +87,15 @@ features, known gaps, and development workflow.
 
 ```xml
 <dependency>
-	<groupId>io.github.shps951023</groupId>
+	<groupId>io.github.mini-software</groupId>
 	<artifactId>minipdf</artifactId>
-	<version>0.1.0</version>
+	<version>0.1.2</version>
 </dependency>
 ```
+
+Maven group IDs may contain hyphens, but Java package names may not. Therefore,
+the dependency uses `io.github.mini-software`, while imports use
+`io.github.minisoftware.minipdf`.
 
 ```java
 import io.github.minisoftware.minipdf.MiniPdf;

--- a/documents/README.fr.md
+++ b/documents/README.fr.md
@@ -7,7 +7,7 @@
 <p>
 <a href="https://www.nuget.org/packages/MiniPdf"><img src="https://img.shields.io/nuget/v/MiniPdf.svg" alt="NuGet"></a>
 <a href="https://crates.io/crates/minipdf"><img src="https://img.shields.io/crates/v/minipdf.svg" alt="crates.io"></a>
-<a href="https://central.sonatype.com/artifact/io.github.shps951023/minipdf"><img src="https://img.shields.io/maven-central/v/io.github.shps951023/minipdf.svg" alt="Maven Central"></a>
+<a href="https://central.sonatype.com/artifact/io.github.mini-software/minipdf"><img src="https://img.shields.io/maven-central/v/io.github.mini-software/minipdf.svg" alt="Maven Central"></a>
 <a href="https://pypi.org/project/minipdf/"><img src="https://img.shields.io/pypi/v/minipdf.svg" alt="PyPI"></a>
 <a href="https://www.npmjs.com/package/minipdf"><img src="https://img.shields.io/npm/v/minipdf.svg" alt="npm"></a>
 <a href="https://pkg.go.dev/github.com/mini-software/MiniPdf/minipdf-go"><img src="https://pkg.go.dev/badge/github.com/mini-software/MiniPdf/minipdf-go.svg" alt="Go Reference"></a>
@@ -83,11 +83,15 @@ Le [guide Rust](../minipdf-rs/README.md) décrit l'API du crate, la CLI, les fon
 
 ```xml
 <dependency>
-	<groupId>io.github.shps951023</groupId>
+	<groupId>io.github.mini-software</groupId>
 	<artifactId>minipdf</artifactId>
-	<version>0.1.0</version>
+	<version>0.1.2</version>
 </dependency>
 ```
+
+Les `groupId` Maven peuvent contenir des traits d’union, contrairement aux noms
+de packages Java. La dépendance utilise donc `io.github.mini-software`, tandis
+que les imports utilisent `io.github.minisoftware.minipdf`.
 
 ```java
 import io.github.minisoftware.minipdf.MiniPdf;

--- a/documents/README.it.md
+++ b/documents/README.it.md
@@ -7,7 +7,7 @@
 <p>
 <a href="https://www.nuget.org/packages/MiniPdf"><img src="https://img.shields.io/nuget/v/MiniPdf.svg" alt="NuGet"></a>
 <a href="https://crates.io/crates/minipdf"><img src="https://img.shields.io/crates/v/minipdf.svg" alt="crates.io"></a>
-<a href="https://central.sonatype.com/artifact/io.github.shps951023/minipdf"><img src="https://img.shields.io/maven-central/v/io.github.shps951023/minipdf.svg" alt="Maven Central"></a>
+<a href="https://central.sonatype.com/artifact/io.github.mini-software/minipdf"><img src="https://img.shields.io/maven-central/v/io.github.mini-software/minipdf.svg" alt="Maven Central"></a>
 <a href="https://pypi.org/project/minipdf/"><img src="https://img.shields.io/pypi/v/minipdf.svg" alt="PyPI"></a>
 <a href="https://www.npmjs.com/package/minipdf"><img src="https://img.shields.io/npm/v/minipdf.svg" alt="npm"></a>
 <a href="https://pkg.go.dev/github.com/mini-software/MiniPdf/minipdf-go"><img src="https://pkg.go.dev/badge/github.com/mini-software/MiniPdf/minipdf-go.svg" alt="Go Reference"></a>
@@ -83,11 +83,15 @@ La [guida Rust](../minipdf-rs/README.md) descrive API del crate, CLI, funzionali
 
 ```xml
 <dependency>
-	<groupId>io.github.shps951023</groupId>
+	<groupId>io.github.mini-software</groupId>
 	<artifactId>minipdf</artifactId>
-	<version>0.1.0</version>
+	<version>0.1.2</version>
 </dependency>
 ```
+
+I `groupId` Maven possono contenere trattini, mentre i nomi dei package Java no.
+Per questo la dipendenza usa `io.github.mini-software` e gli import usano
+`io.github.minisoftware.minipdf`.
 
 ```java
 import io.github.minisoftware.minipdf.MiniPdf;

--- a/documents/README.ja.md
+++ b/documents/README.ja.md
@@ -7,7 +7,7 @@
 <p>
 <a href="https://www.nuget.org/packages/MiniPdf"><img src="https://img.shields.io/nuget/v/MiniPdf.svg" alt="NuGet"></a>
 <a href="https://crates.io/crates/minipdf"><img src="https://img.shields.io/crates/v/minipdf.svg" alt="crates.io"></a>
-<a href="https://central.sonatype.com/artifact/io.github.shps951023/minipdf"><img src="https://img.shields.io/maven-central/v/io.github.shps951023/minipdf.svg" alt="Maven Central"></a>
+<a href="https://central.sonatype.com/artifact/io.github.mini-software/minipdf"><img src="https://img.shields.io/maven-central/v/io.github.mini-software/minipdf.svg" alt="Maven Central"></a>
 <a href="https://pypi.org/project/minipdf/"><img src="https://img.shields.io/pypi/v/minipdf.svg" alt="PyPI"></a>
 <a href="https://www.npmjs.com/package/minipdf"><img src="https://img.shields.io/npm/v/minipdf.svg" alt="npm"></a>
 <a href="https://pkg.go.dev/github.com/mini-software/MiniPdf/minipdf-go"><img src="https://pkg.go.dev/badge/github.com/mini-software/MiniPdf/minipdf-go.svg" alt="Go Reference"></a>
@@ -83,11 +83,15 @@ minipdf report.docx -o report.pdf
 
 ```xml
 <dependency>
-	<groupId>io.github.shps951023</groupId>
+	<groupId>io.github.mini-software</groupId>
 	<artifactId>minipdf</artifactId>
-	<version>0.1.0</version>
+	<version>0.1.2</version>
 </dependency>
 ```
+
+Maven の `groupId` ではハイフンを使用できますが、Java のパッケージ名では使用できません。
+そのため、依存関係には `io.github.mini-software`、import には
+`io.github.minisoftware.minipdf` を使用します。
 
 ```java
 import io.github.minisoftware.minipdf.MiniPdf;

--- a/documents/README.ko.md
+++ b/documents/README.ko.md
@@ -7,7 +7,7 @@
 <p>
 <a href="https://www.nuget.org/packages/MiniPdf"><img src="https://img.shields.io/nuget/v/MiniPdf.svg" alt="NuGet"></a>
 <a href="https://crates.io/crates/minipdf"><img src="https://img.shields.io/crates/v/minipdf.svg" alt="crates.io"></a>
-<a href="https://central.sonatype.com/artifact/io.github.shps951023/minipdf"><img src="https://img.shields.io/maven-central/v/io.github.shps951023/minipdf.svg" alt="Maven Central"></a>
+<a href="https://central.sonatype.com/artifact/io.github.mini-software/minipdf"><img src="https://img.shields.io/maven-central/v/io.github.mini-software/minipdf.svg" alt="Maven Central"></a>
 <a href="https://pypi.org/project/minipdf/"><img src="https://img.shields.io/pypi/v/minipdf.svg" alt="PyPI"></a>
 <a href="https://www.npmjs.com/package/minipdf"><img src="https://img.shields.io/npm/v/minipdf.svg" alt="npm"></a>
 <a href="https://pkg.go.dev/github.com/mini-software/MiniPdf/minipdf-go"><img src="https://pkg.go.dev/badge/github.com/mini-software/MiniPdf/minipdf-go.svg" alt="Go Reference"></a>
@@ -83,11 +83,15 @@ minipdf report.docx -o report.pdf
 
 ```xml
 <dependency>
-	<groupId>io.github.shps951023</groupId>
+	<groupId>io.github.mini-software</groupId>
 	<artifactId>minipdf</artifactId>
-	<version>0.1.0</version>
+	<version>0.1.2</version>
 </dependency>
 ```
+
+Maven `groupId`에는 하이픈을 사용할 수 있지만 Java 패키지 이름에는 사용할 수 없습니다.
+따라서 의존성에는 `io.github.mini-software`를 사용하고 import에는
+`io.github.minisoftware.minipdf`를 사용합니다.
 
 ```java
 import io.github.minisoftware.minipdf.MiniPdf;

--- a/documents/README.zh-CN.md
+++ b/documents/README.zh-CN.md
@@ -7,7 +7,7 @@
 <p>
 <a href="https://www.nuget.org/packages/MiniPdf"><img src="https://img.shields.io/nuget/v/MiniPdf.svg" alt="NuGet"></a>
 <a href="https://crates.io/crates/minipdf"><img src="https://img.shields.io/crates/v/minipdf.svg" alt="crates.io"></a>
-<a href="https://central.sonatype.com/artifact/io.github.shps951023/minipdf"><img src="https://img.shields.io/maven-central/v/io.github.shps951023/minipdf.svg" alt="Maven Central"></a>
+<a href="https://central.sonatype.com/artifact/io.github.mini-software/minipdf"><img src="https://img.shields.io/maven-central/v/io.github.mini-software/minipdf.svg" alt="Maven Central"></a>
 <a href="https://pypi.org/project/minipdf/"><img src="https://img.shields.io/pypi/v/minipdf.svg" alt="PyPI"></a>
 <a href="https://www.npmjs.com/package/minipdf"><img src="https://img.shields.io/npm/v/minipdf.svg" alt="npm"></a>
 <a href="https://pkg.go.dev/github.com/mini-software/MiniPdf/minipdf-go"><img src="https://pkg.go.dev/badge/github.com/mini-software/MiniPdf/minipdf-go.svg" alt="Go Reference"></a>
@@ -83,11 +83,14 @@ minipdf report.docx -o report.pdf
 
 ```xml
 <dependency>
-	<groupId>io.github.shps951023</groupId>
+	<groupId>io.github.mini-software</groupId>
 	<artifactId>minipdf</artifactId>
-	<version>0.1.0</version>
+	<version>0.1.2</version>
 </dependency>
 ```
+
+Maven `groupId` 可以包含连字符，但 Java 包名不能。因此依赖坐标使用
+`io.github.mini-software`，import 使用 `io.github.minisoftware.minipdf`。
 
 ```java
 import io.github.minisoftware.minipdf.MiniPdf;

--- a/documents/README.zh-TW.md
+++ b/documents/README.zh-TW.md
@@ -7,7 +7,7 @@
 <p>
 <a href="https://www.nuget.org/packages/MiniPdf"><img src="https://img.shields.io/nuget/v/MiniPdf.svg" alt="NuGet"></a>
 <a href="https://crates.io/crates/minipdf"><img src="https://img.shields.io/crates/v/minipdf.svg" alt="crates.io"></a>
-<a href="https://central.sonatype.com/artifact/io.github.shps951023/minipdf"><img src="https://img.shields.io/maven-central/v/io.github.shps951023/minipdf.svg" alt="Maven Central"></a>
+<a href="https://central.sonatype.com/artifact/io.github.mini-software/minipdf"><img src="https://img.shields.io/maven-central/v/io.github.mini-software/minipdf.svg" alt="Maven Central"></a>
 <a href="https://pypi.org/project/minipdf/"><img src="https://img.shields.io/pypi/v/minipdf.svg" alt="PyPI"></a>
 <a href="https://www.npmjs.com/package/minipdf"><img src="https://img.shields.io/npm/v/minipdf.svg" alt="npm"></a>
 <a href="https://pkg.go.dev/github.com/mini-software/MiniPdf/minipdf-go"><img src="https://pkg.go.dev/badge/github.com/mini-software/MiniPdf/minipdf-go.svg" alt="Go Reference"></a>
@@ -83,11 +83,14 @@ minipdf report.docx -o report.pdf
 
 ```xml
 <dependency>
-	<groupId>io.github.shps951023</groupId>
+	<groupId>io.github.mini-software</groupId>
 	<artifactId>minipdf</artifactId>
-	<version>0.1.0</version>
+	<version>0.1.2</version>
 </dependency>
 ```
+
+Maven `groupId` 可以包含連字號，但 Java 套件名稱不能。因此相依套件座標使用
+`io.github.mini-software`，import 使用 `io.github.minisoftware.minipdf`。
 
 ```java
 import io.github.minisoftware.minipdf.MiniPdf;

--- a/minipdf-java/README.md
+++ b/minipdf-java/README.md
@@ -9,11 +9,15 @@ The library is available from Maven Central:
 
 ```xml
 <dependency>
-    <groupId>io.github.shps951023</groupId>
+    <groupId>io.github.mini-software</groupId>
     <artifactId>minipdf</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
 </dependency>
 ```
+
+  Maven group IDs may contain hyphens, but Java package names may not. Therefore,
+  the dependency uses `io.github.mini-software`, while imports use
+  `io.github.minisoftware.minipdf`.
 
 ## Library
 
@@ -36,14 +40,14 @@ Download the executable JAR with Maven:
 
 ```powershell
 mvn dependency:copy `
-  -Dartifact=io.github.shps951023:minipdf-cli:0.1.1 `
+  -Dartifact=io.github.mini-software:minipdf-cli:0.1.2 `
   -DoutputDirectory=.
 ```
 
 Convert a document:
 
 ```powershell
-java -jar minipdf-cli-0.1.1.jar input.pptx -o output.pdf
+java -jar minipdf-cli-0.1.2.jar input.pptx -o output.pdf
 ```
 
 The CLI accepts `.docx`, `.xlsx`, and `.pptx` files. Run it with `--help` for

--- a/minipdf-java/minipdf-cli/pom.xml
+++ b/minipdf-java/minipdf-cli/pom.xml
@@ -5,9 +5,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.shps951023</groupId>
+        <groupId>io.github.mini-software</groupId>
         <artifactId>minipdf-java-parent</artifactId>
-        <version>0.1.1</version>
+        <version>0.1.2</version>
     </parent>
 
     <artifactId>minipdf-cli</artifactId>

--- a/minipdf-java/minipdf-cli/src/main/java/io/github/minisoftware/minipdf/cli/MiniPdfCommand.java
+++ b/minipdf-java/minipdf-cli/src/main/java/io/github/minisoftware/minipdf/cli/MiniPdfCommand.java
@@ -20,7 +20,7 @@ import java.util.concurrent.Callable;
 
 @Command(
         name = "minipdf",
-    version = "minipdf-java 0.1.1",
+    version = "minipdf-java 0.1.2",
     description = "Convert XLSX, DOCX, and PPTX files to PDF with the Java MiniPdf engine.",
         mixinStandardHelpOptions = true,
         subcommands = MiniPdfCommand.ConvertCommand.class)

--- a/minipdf-java/minipdf/pom.xml
+++ b/minipdf-java/minipdf/pom.xml
@@ -5,9 +5,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.shps951023</groupId>
+        <groupId>io.github.mini-software</groupId>
         <artifactId>minipdf-java-parent</artifactId>
-        <version>0.1.1</version>
+        <version>0.1.2</version>
     </parent>
 
     <artifactId>minipdf</artifactId>

--- a/minipdf-java/pom.xml
+++ b/minipdf-java/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.github.shps951023</groupId>
+    <groupId>io.github.mini-software</groupId>
     <artifactId>minipdf-java-parent</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
     <packaging>pom</packaging>
 
     <name>MiniPdf for Java</name>


### PR DESCRIPTION
## Summary

- move Java Maven coordinates from the personal namespace to the verified `io.github.mini-software` organization namespace
- bump the Java parent, library, CLI, and CLI version output to `0.1.2`
- update the main README, Java guide, badges, CLI examples, and all translated READMEs
- document why Maven uses `mini-software` while Java packages use `minisoftware`

## Validation

- `mvn -B -ntp clean verify`
- `mvn -ntp -Prelease verify`
- `java -jar minipdf-cli-0.1.2.jar --version`

Both Maven reactor builds passed for all three modules, including source/Javadoc generation and GPG signing. Maven Central deployment will run from a clean `main` checkout after this PR is merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Maven Central badges and dependency examples across all available README languages.
  - Updated Java and CLI dependency coordinates to the `io.github.mini-software` group.
  - Bumped documented dependency and library versions to `0.1.2`.
  - Added clarification distinguishing Maven group IDs from Java package names and imports.
  - Updated CLI version information to `0.1.2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->