### PR TITLE
Fix unspecified XLSX paper size default

### DIFF
--- a/src/MiniPdf/ExcelReader.cs
+++ b/src/MiniPdf/ExcelReader.cs
@@ -131,8 +131,7 @@ internal static class ExcelReader
             }
             if (sheet.PaperSize == 0)
             {
-                sheet.PaperSize = firstExplicitPaperSize ??
-                    (sheet.Rows.Count >= 1000 && sheet.ColumnWidths.Count == 0 && sheet.DefaultColumnWidth <= 0f ? 9 : 1);
+                sheet.PaperSize = firstExplicitPaperSize ?? 9;
             }
         }
 
@@ -3111,7 +3110,7 @@ internal static class ExcelReader
     {
         var isLandscape = false;
         var scale = 100;
-        var paperSize = 0; // 0 = not specified (will inherit from first sheet or default to US Letter)
+        var paperSize = 0; // 0 = not specified (will inherit from first sheet or default to A4)
         float marginLeft = -1, marginRight = -1, marginTop = -1, marginBottom = -1, footerMargin = -1;
         var fitToPage = false;
         var fitToPageInferred = false;

--- a/tests/MiniPdf.Tests/ExcelToPdfConverterTests.cs
+++ b/tests/MiniPdf.Tests/ExcelToPdfConverterTests.cs
@@ -27,6 +27,30 @@ public class ExcelToPdfConverterTests
     }
 
     [Fact]
+    public void Convert_WithoutPaperSize_UsesA4Page()
+    {
+        using var excelStream = CreateSimpleExcel(new[] { new[] { "A4" } });
+
+        var page = Assert.Single(ExcelToPdfConverter.Convert(excelStream).Pages);
+
+        Assert.Equal(595.2756f, page.Width, 3);
+        Assert.Equal(841.8898f, page.Height, 3);
+    }
+
+    [Fact]
+    public void Convert_WithExplicitLetterPaperSize_UsesLetterPage()
+    {
+        using var excelStream = CreateSimpleExcel(
+            new[] { new[] { "Letter" } },
+            includeUnflaggedFitAttributes: true);
+
+        var page = Assert.Single(ExcelToPdfConverter.Convert(excelStream).Pages);
+
+        Assert.Equal(612f, page.Width, 3);
+        Assert.Equal(792f, page.Height, 3);
+    }
+
+    [Fact]
     public void Convert_WorksheetImage_RendersAboveCellText()
     {
         using var excelStream = CreateExcelWithImageOverCell();


### PR DESCRIPTION
## Summary

- default XLSX worksheets without an explicit `paperSize` to A4, matching the Microsoft 365 benchmark output
- preserve explicit `paperSize="1"` as US Letter
- add regression tests for both omitted and explicit paper-size behavior

## Validation

- `dotnet test tests/MiniPdf.Tests`: 188 passed
- `classic84_travel_destination_cards`: MiniPdf and reference PNGs both `1241 x 1754`
- focused visual score improved from approximately `0.9582` to `0.9963`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Excel sheets without a specified paper size now consistently use A4 dimensions by default.
  * Explicitly configured Letter-size sheets continue to generate Letter-sized pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->