### PR TITLE
Fix AI security scan transport failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,10 +116,30 @@ jobs:
               temperature: 0.1
             }')
           
-          RESPONSE=$(curl -s "$URL" \
+          CURL_EXIT=0
+          RESPONSE=$(curl --silent --show-error \
+            --retry 4 \
+            --retry-all-errors \
+            --retry-delay 2 \
+            --connect-timeout 15 \
+            --max-time 120 \
+            "$URL" \
             -H "Content-Type: application/json" \
             -H "api-key: $AZURE_OPENAI_API_KEY" \
-            -d "$PAYLOAD")
+            -d "$PAYLOAD") || CURL_EXIT=$?
+
+          if [ "$CURL_EXIT" -ne 0 ]; then
+            case "$CURL_EXIT" in
+              5|6|7|28|35|52|56)
+                echo "::warning::AI Security Review unavailable after retries (curl exit $CURL_EXIT); skipping external review"
+                exit 0
+                ;;
+              *)
+                echo "::error::AI Security Review request failed (curl exit $CURL_EXIT)"
+                exit "$CURL_EXIT"
+                ;;
+            esac
+          fi
           
           # Extract content
           CONTENT=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // empty')


### PR DESCRIPTION
## Summary
- retry Azure OpenAI requests on transient transport failures with bounded connection and request timeouts
- downgrade known DNS, connection, timeout, TLS, and receive failures to a warning after retries
- keep malformed configuration, invalid AI responses, and actual security findings blocking

This addresses the repeated `curl` exit code 6 failure in CI run 34045536522.

## Validation
- simulated DNS failure: curl exit 6 is handled without failing the job
- simulated malformed URL: curl exit 3 remains blocking
- GitHub Actions YAML diagnostics pass
- `git diff --check` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of automated security reviews by retrying transient network requests.
  * Added request timeouts and clearer handling for temporary versus critical failures.
  * Critical request failures now properly stop the workflow with an appropriate error status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->