### PR TITLE
Show deployed MiniPdf NuGet version

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,8 +38,21 @@ jobs:
           curl -L -o MiniPdf.Web/MiniPdf.Web.Client/wwwroot/fonts/NotoSansSC-Regular.ttf \
             "https://github.com/google/fonts/raw/main/ofl/notosanssc/NotoSansSC%5Bwght%5D.ttf"
 
+      - name: Resolve MiniPdf NuGet version
+        id: minipdf-version
+        shell: pwsh
+        run: |
+          $index = Invoke-RestMethod 'https://api.nuget.org/v3-flatcontainer/minipdf/index.json'
+          $version = $index.versions |
+            Where-Object { $_ -notmatch '-' } |
+            Select-Object -Last 1
+          if (-not $version) {
+            throw 'Could not resolve the latest stable MiniPdf version from NuGet.'
+          }
+          "version=$version" >> $env:GITHUB_OUTPUT
+
       - name: Publish Blazor WASM
-        run: dotnet publish MiniPdf.Web/MiniPdf.Web.Client/MiniPdf.Web.Client.csproj -c Release -o publish
+        run: dotnet publish MiniPdf.Web/MiniPdf.Web.Client/MiniPdf.Web.Client.csproj -c Release -o publish -p:Version=${{ steps.minipdf-version.outputs.version }}
 
       - name: Remove pre-compressed files (GitHub Pages does not support content negotiation)
         run: find publish/wwwroot -name '*.br' -o -name '*.gz' | xargs rm -f

--- a/MiniPdf.Web/MiniPdf.Web.Client/Pages/Converter.razor
+++ b/MiniPdf.Web/MiniPdf.Web.Client/Pages/Converter.razor
@@ -25,6 +25,7 @@
             <line x1="9" y1="15" x2="15" y2="15"/>
         </svg>
         <h1>MiniPdf</h1>
+        <a class="package-version" href="https://www.nuget.org/packages/MiniPdf/@MiniPdfVersion" target="_blank" rel="noopener noreferrer">NuGet v@(MiniPdfVersion)</a>
     </div>
     <p class="subtitle">@L.T("Subtitle") &mdash; @L.T("PoweredBy") <a href="https://github.com/mini-software/MiniPdf" target="_blank">MiniPdf</a></p>
 
@@ -307,6 +308,13 @@
     private const string ApiStatusUrl = ApiBaseUrl + "/api/status";
     private const string ApiStatsUrl = ApiBaseUrl + "/api/stats";
     private const string DefaultFontCacheKey = "NotoSansSC-Regular.ttf";
+    private static readonly string MiniPdfVersion =
+        typeof(MiniSoftware.MiniPdf).Assembly
+            .GetCustomAttributes(typeof(System.Reflection.AssemblyInformationalVersionAttribute), false)
+            .OfType<System.Reflection.AssemblyInformationalVersionAttribute>()
+            .FirstOrDefault()?.InformationalVersion.Split('+')[0]
+        ?? typeof(MiniSoftware.MiniPdf).Assembly.GetName().Version?.ToString(3)
+        ?? "unknown";
 
     private IBrowserFile? selectedFile;
     private bool isConverting;

--- a/MiniPdf.Web/MiniPdf.Web.Client/wwwroot/app.css
+++ b/MiniPdf.Web/MiniPdf.Web.Client/wwwroot/app.css
@@ -101,6 +101,24 @@ h1:focus { outline: none; }
     letter-spacing: -.02em;
 }
 
+.package-version {
+    padding: .2rem .45rem;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text-secondary);
+    font-size: .68rem;
+    font-weight: 600;
+    line-height: 1;
+    text-decoration: none;
+    transition: border-color var(--transition), color var(--transition), background var(--transition);
+}
+
+.package-version:hover {
+    border-color: var(--accent);
+    background: var(--accent-light);
+    color: var(--accent);
+}
+
 .subtitle {
     color: var(--text-secondary);
     font-size: .9rem;


### PR DESCRIPTION
## Summary
- show the deployed MiniPdf version beside the web converter title
- link the badge to the matching NuGet package version
- resolve the latest stable MiniPdf version from NuGet during GitHub Pages deployment and stamp it into the WASM build

## Validation
- `dotnet build MiniPdf.Web/MiniPdf.Web.Client/MiniPdf.Web.Client.csproj -c Release -p:Version=0.41.1`
- verified desktop and 375px mobile layouts
- confirmed the badge renders `NuGet v0.41.1` and links to the matching package page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a NuGet package version link to the converter page.
  - Added styling for the version badge, including hover states.

- **Bug Fixes**
  - Deployment builds now automatically use the latest stable MiniPdf NuGet package version.
  - Builds fail when no stable package version is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->