### PR TITLE
Fix NuGet source repository links

### DIFF
--- a/src/MiniPdf.Cli/MiniPdf.Cli.csproj
+++ b/src/MiniPdf.Cli/MiniPdf.Cli.csproj
@@ -23,8 +23,8 @@
     <Description>A command-line tool to convert Office files to PDF. Powered by MiniPdf.</Description>
     <PackageTags>pdf;excel;xlsx;word;docx;powerpoint;pptx;converter;cli;tool;minipdf</PackageTags>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/shps951023/MiniPdf</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/shps951023/MiniPdf.git</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/mini-software/MiniPdf</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/mini-software/MiniPdf.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.nuget.cli.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>

--- a/src/MiniPdf/MiniPdf.csproj
+++ b/src/MiniPdf/MiniPdf.csproj
@@ -14,8 +14,8 @@
     <Description>A minimal, zero-dependency .NET library for generating PDF documents from text, Excel, Word, and PowerPoint files.</Description>
     <PackageTags>pdf;excel;xlsx;word;docx;powerpoint;pptx;converter;text;minipdf</PackageTags>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/shps951023/MiniPdf</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/shps951023/MiniPdf.git</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/mini-software/MiniPdf</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/mini-software/MiniPdf.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.nuget.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary
- update `PackageProjectUrl` for `MiniPdf` and `MiniPdf.Cli` to the `mini-software/MiniPdf` organization repository
- update `RepositoryUrl` for both packages to the matching Git repository URL

NuGet packages are immutable, so the existing `0.41.1` package metadata cannot be replaced. The corrected Source repository link will appear starting with the next published version.

## Validation
Packed both projects with a temporary version and inspected the generated `.nuspec` files:
- `MiniPdf`: project and repository URLs point to `mini-software/MiniPdf`
- `MiniPdf.Cli`: project and repository URLs point to `mini-software/MiniPdf`
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated NuGet package project and repository links to point to the current MiniPdf GitHub repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->