### PR TITLE
Allow release workflow to dispatch artifact builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
         type: string
 
 permissions:
+  actions: write
   contents: write
 
 concurrency:


### PR DESCRIPTION
## Summary
- grant the release workflow `actions: write` permission
- allow its authenticated `gh workflow run` commands to dispatch CLI AOT, GUI AOT, and NuGet workflows

## Evidence
The v0.42.0 release run completed build, tests, citation update, and GitHub Release creation, then failed in `Start release artifact workflows` with HTTP 403 `Resource not accessible by integration`.

Failed run: https://github.com/mini-software/MiniPdf/actions/runs/34086598272

The v0.42.0 downstream workflows were manually dispatched to complete the release.