### PR TITLE
Fix registered fonts for Java DOCX and PPTX conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ features, known gaps, and development workflow.
 <dependency>
 	<groupId>io.github.mini-software</groupId>
 	<artifactId>minipdf</artifactId>
-	<version>0.1.5</version>
+	<version>0.1.6</version>
 </dependency>
 ```
 
@@ -99,10 +99,18 @@ the dependency uses `io.github.mini-software`, while imports use
 
 ```java
 import io.github.minisoftware.minipdf.MiniPdf;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
+MiniPdf.registerFont(
+		"Noto Sans",
+		Files.readAllBytes(Path.of("fonts/NotoSans-Regular.ttf")));
 MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
+MiniPdf.clearRegisteredFonts();
 ```
+
+Registered fonts are used by DOCX, XLSX, and PPTX conversion. Registrations are
+process-wide; clear them before configuring a different font set.
 
 ### Python
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ implementation that matches your project.
 |---|---|---|---|---|---|
 | .NET | XLSX, DOCX, PPTX | Library, CLI, Native AOT binaries | Stable | **[.NET guide](documents/README.nuget.md)** | **[XLSX](tests/MiniPdf.Benchmark/reports/comparison_report.md)**<br>**[DOCX](tests/MiniPdf.Benchmark/reports_docx/comparison_report.md)**<br>**[PPTX](tests/Issue_Files/reports_pptx/comparison_report.md)** |
 | Rust | XLSX, DOCX, PPTX | Crate, CLI | Experimental | **[Rust guide](minipdf-rs/README.md)** | **[XLSX](artifacts/rust-benchmark/classic/xlsx/report/comparison_report.md)**<br>**[DOCX](artifacts/rust-benchmark/classic/docx/report/comparison_report.md)** |
-| Java | XLSX, DOCX | Library, CLI | Experimental | **[Java source](minipdf-java/)** | **[XLSX](artifacts/java-benchmark/issue/xlsx/report/comparison_report.md)** |
+| Java | XLSX, DOCX, PPTX | Library, CLI | Experimental | **[Java source](minipdf-java/)** | **[XLSX](artifacts/java-benchmark/issue/xlsx/report/comparison_report.md)** |
 | Python | DOCX | Package, CLI | Experimental | **[Python guide](minipdf-python/README.md)** | **[XLSX](artifacts/python-benchmark/issue/xlsx/report/comparison_report.md)** |
 | Node.js | XLSX, DOCX, PPTX | Native package | Experimental | **[Node.js guide](minipdf-node/README.md)** | **[XLSX](artifacts/node-benchmark/issue/xlsx/report/comparison_report.md)** |
 | Go | XLSX, DOCX, PPTX | Package, CLI | Experimental | **[Go guide](minipdf-go/README.md)** | **[XLSX](artifacts/go-benchmark/issue/xlsx/report/comparison_report.md)** |
@@ -102,11 +102,14 @@ import io.github.minisoftware.minipdf.MiniPdf;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-MiniPdf.registerFont(
-		"Noto Sans",
-		Files.readAllBytes(Path.of("fonts/NotoSans-Regular.ttf")));
-MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
-MiniPdf.clearRegisteredFonts();
+try {
+	MiniPdf.registerFont(
+			"Noto Sans",
+			Files.readAllBytes(Path.of("fonts/NotoSans-Regular.ttf")));
+	MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
+} finally {
+	MiniPdf.clearRegisteredFonts();
+}
 ```
 
 Registered fonts are used by DOCX, XLSX, and PPTX conversion. Registrations are

--- a/documents/README.fr.md
+++ b/documents/README.fr.md
@@ -85,7 +85,7 @@ Le [guide Rust](../minipdf-rs/README.md) décrit l'API du crate, la CLI, les fon
 <dependency>
 	<groupId>io.github.mini-software</groupId>
 	<artifactId>minipdf</artifactId>
-	<version>0.1.5</version>
+	<version>0.1.6</version>
 </dependency>
 ```
 
@@ -95,10 +95,19 @@ que les imports utilisent `io.github.minisoftware.minipdf`.
 
 ```java
 import io.github.minisoftware.minipdf.MiniPdf;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
+MiniPdf.registerFont(
+		"Noto Sans",
+		Files.readAllBytes(Path.of("fonts/NotoSans-Regular.ttf")));
 MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
+MiniPdf.clearRegisteredFonts();
 ```
+
+Les polices enregistrées sont utilisées lors de la conversion des fichiers DOCX,
+XLSX et PPTX. Les enregistrements s'appliquent à l'ensemble du processus ;
+effacez-les avant de configurer un autre jeu de polices.
 
 ### Python
 

--- a/documents/README.fr.md
+++ b/documents/README.fr.md
@@ -34,7 +34,7 @@ MiniPdf convertit directement les documents Office en PDF sans nécessiter Micro
 |---|---|---|---|---|---|
 | .NET | XLSX, DOCX, PPTX | Bibliothèque, CLI, binaires Native AOT | Stable | **[Guide .NET](README.nuget.md)** | **[XLSX](../tests/MiniPdf.Benchmark/reports/comparison_report.md)**<br>**[DOCX](../tests/MiniPdf.Benchmark/reports_docx/comparison_report.md)**<br>**[PPTX](../tests/Issue_Files/reports_pptx/comparison_report.md)** |
 | Rust | XLSX, DOCX, PPTX | Crate, CLI | Expérimental | **[Guide Rust](../minipdf-rs/README.md)** | **[XLSX](../artifacts/rust-benchmark/classic/xlsx/report/comparison_report.md)**<br>**[DOCX](../artifacts/rust-benchmark/classic/docx/report/comparison_report.md)** |
-| Java | XLSX, DOCX | Bibliothèque, CLI | Expérimental | **[Sources Java](../minipdf-java/)** | **[XLSX](../artifacts/java-benchmark/issue/xlsx/report/comparison_report.md)** |
+| Java | XLSX, DOCX, PPTX | Bibliothèque, CLI | Expérimental | **[Sources Java](../minipdf-java/)** | **[XLSX](../artifacts/java-benchmark/issue/xlsx/report/comparison_report.md)** |
 | Python | DOCX | Paquet, CLI | Expérimental | **[Guide Python](../minipdf-python/README.md)** | **[XLSX](../artifacts/python-benchmark/issue/xlsx/report/comparison_report.md)** |
 | Node.js | XLSX, DOCX, PPTX | Paquet natif | Expérimental | **[Guide Node.js](../minipdf-node/README.md)** | **[XLSX](../artifacts/node-benchmark/issue/xlsx/report/comparison_report.md)** |
 | Go | XLSX, DOCX, PPTX | Paquet, CLI | Expérimental | **[Guide Go](../minipdf-go/README.md)** | **[XLSX](../artifacts/go-benchmark/issue/xlsx/report/comparison_report.md)** |
@@ -98,11 +98,14 @@ import io.github.minisoftware.minipdf.MiniPdf;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-MiniPdf.registerFont(
-		"Noto Sans",
-		Files.readAllBytes(Path.of("fonts/NotoSans-Regular.ttf")));
-MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
-MiniPdf.clearRegisteredFonts();
+try {
+	MiniPdf.registerFont(
+			"Noto Sans",
+			Files.readAllBytes(Path.of("fonts/NotoSans-Regular.ttf")));
+	MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
+} finally {
+	MiniPdf.clearRegisteredFonts();
+}
 ```
 
 Les polices enregistrées sont utilisées lors de la conversion des fichiers DOCX,

--- a/documents/README.it.md
+++ b/documents/README.it.md
@@ -34,7 +34,7 @@ MiniPdf converte direttamente i documenti Office in PDF senza richiedere Microso
 |---|---|---|---|---|---|
 | .NET | XLSX, DOCX, PPTX | Libreria, CLI, binari Native AOT | Stabile | **[Guida .NET](README.nuget.md)** | **[XLSX](../tests/MiniPdf.Benchmark/reports/comparison_report.md)**<br>**[DOCX](../tests/MiniPdf.Benchmark/reports_docx/comparison_report.md)**<br>**[PPTX](../tests/Issue_Files/reports_pptx/comparison_report.md)** |
 | Rust | XLSX, DOCX, PPTX | Crate, CLI | Sperimentale | **[Guida Rust](../minipdf-rs/README.md)** | **[XLSX](../artifacts/rust-benchmark/classic/xlsx/report/comparison_report.md)**<br>**[DOCX](../artifacts/rust-benchmark/classic/docx/report/comparison_report.md)** |
-| Java | XLSX, DOCX | Libreria, CLI | Sperimentale | **[Sorgenti Java](../minipdf-java/)** | **[XLSX](../artifacts/java-benchmark/issue/xlsx/report/comparison_report.md)** |
+| Java | XLSX, DOCX, PPTX | Libreria, CLI | Sperimentale | **[Sorgenti Java](../minipdf-java/)** | **[XLSX](../artifacts/java-benchmark/issue/xlsx/report/comparison_report.md)** |
 | Python | DOCX | Pacchetto, CLI | Sperimentale | **[Guida Python](../minipdf-python/README.md)** | **[XLSX](../artifacts/python-benchmark/issue/xlsx/report/comparison_report.md)** |
 | Node.js | XLSX, DOCX, PPTX | Pacchetto nativo | Sperimentale | **[Guida Node.js](../minipdf-node/README.md)** | **[XLSX](../artifacts/node-benchmark/issue/xlsx/report/comparison_report.md)** |
 | Go | XLSX, DOCX, PPTX | Pacchetto, CLI | Sperimentale | **[Guida Go](../minipdf-go/README.md)** | **[XLSX](../artifacts/go-benchmark/issue/xlsx/report/comparison_report.md)** |
@@ -98,11 +98,14 @@ import io.github.minisoftware.minipdf.MiniPdf;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-MiniPdf.registerFont(
-		"Noto Sans",
-		Files.readAllBytes(Path.of("fonts/NotoSans-Regular.ttf")));
-MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
-MiniPdf.clearRegisteredFonts();
+try {
+	MiniPdf.registerFont(
+			"Noto Sans",
+			Files.readAllBytes(Path.of("fonts/NotoSans-Regular.ttf")));
+	MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
+} finally {
+	MiniPdf.clearRegisteredFonts();
+}
 ```
 
 I font registrati vengono usati nella conversione di DOCX, XLSX e PPTX. Le

--- a/documents/README.it.md
+++ b/documents/README.it.md
@@ -85,7 +85,7 @@ La [guida Rust](../minipdf-rs/README.md) descrive API del crate, CLI, funzionali
 <dependency>
 	<groupId>io.github.mini-software</groupId>
 	<artifactId>minipdf</artifactId>
-	<version>0.1.5</version>
+	<version>0.1.6</version>
 </dependency>
 ```
 
@@ -95,10 +95,19 @@ Per questo la dipendenza usa `io.github.mini-software` e gli import usano
 
 ```java
 import io.github.minisoftware.minipdf.MiniPdf;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
+MiniPdf.registerFont(
+		"Noto Sans",
+		Files.readAllBytes(Path.of("fonts/NotoSans-Regular.ttf")));
 MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
+MiniPdf.clearRegisteredFonts();
 ```
+
+I font registrati vengono usati nella conversione di DOCX, XLSX e PPTX. Le
+registrazioni valgono per l'intero processo; cancellale prima di configurare un
+set di font diverso.
 
 ### Python
 

--- a/documents/README.ja.md
+++ b/documents/README.ja.md
@@ -34,7 +34,7 @@ MiniPdf は、実行時に Microsoft Office、LibreOffice、Adobe Acrobat、COM 
 |---|---|---|---|---|---|
 | .NET | XLSX、DOCX、PPTX | ライブラリ、CLI、Native AOT バイナリ | 安定版 | **[.NET ガイド](README.nuget.md)** | **[XLSX](../tests/MiniPdf.Benchmark/reports/comparison_report.md)**<br>**[DOCX](../tests/MiniPdf.Benchmark/reports_docx/comparison_report.md)**<br>**[PPTX](../tests/Issue_Files/reports_pptx/comparison_report.md)** |
 | Rust | XLSX、DOCX、PPTX | Crate、CLI | 実験版 | **[Rust ガイド](../minipdf-rs/README.md)** | **[XLSX](../artifacts/rust-benchmark/classic/xlsx/report/comparison_report.md)**<br>**[DOCX](../artifacts/rust-benchmark/classic/docx/report/comparison_report.md)** |
-| Java | XLSX、DOCX | ライブラリ、CLI | 実験版 | **[Java ソース](../minipdf-java/)** | **[XLSX](../artifacts/java-benchmark/issue/xlsx/report/comparison_report.md)** |
+| Java | XLSX、DOCX、PPTX | ライブラリ、CLI | 実験版 | **[Java ソース](../minipdf-java/)** | **[XLSX](../artifacts/java-benchmark/issue/xlsx/report/comparison_report.md)** |
 | Python | DOCX | パッケージ、CLI | 実験版 | **[Python ガイド](../minipdf-python/README.md)** | **[XLSX](../artifacts/python-benchmark/issue/xlsx/report/comparison_report.md)** |
 | Node.js | XLSX、DOCX、PPTX | ネイティブパッケージ | 実験版 | **[Node.js ガイド](../minipdf-node/README.md)** | **[XLSX](../artifacts/node-benchmark/issue/xlsx/report/comparison_report.md)** |
 | Go | XLSX、DOCX、PPTX | パッケージ、CLI | 実験版 | **[Go ガイド](../minipdf-go/README.md)** | **[XLSX](../artifacts/go-benchmark/issue/xlsx/report/comparison_report.md)** |
@@ -98,11 +98,14 @@ import io.github.minisoftware.minipdf.MiniPdf;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-MiniPdf.registerFont(
-		"Noto Sans",
-		Files.readAllBytes(Path.of("fonts/NotoSans-Regular.ttf")));
-MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
-MiniPdf.clearRegisteredFonts();
+try {
+	MiniPdf.registerFont(
+			"Noto Sans",
+			Files.readAllBytes(Path.of("fonts/NotoSans-Regular.ttf")));
+	MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
+} finally {
+	MiniPdf.clearRegisteredFonts();
+}
 ```
 
 登録したフォントは DOCX、XLSX、PPTX の変換で使用されます。登録内容は

--- a/documents/README.ja.md
+++ b/documents/README.ja.md
@@ -85,7 +85,7 @@ minipdf report.docx -o report.pdf
 <dependency>
 	<groupId>io.github.mini-software</groupId>
 	<artifactId>minipdf</artifactId>
-	<version>0.1.5</version>
+	<version>0.1.6</version>
 </dependency>
 ```
 
@@ -95,10 +95,18 @@ Maven の `groupId` ではハイフンを使用できますが、Java のパッ�
 
 ```java
 import io.github.minisoftware.minipdf.MiniPdf;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
+MiniPdf.registerFont(
+		"Noto Sans",
+		Files.readAllBytes(Path.of("fonts/NotoSans-Regular.ttf")));
 MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
+MiniPdf.clearRegisteredFonts();
 ```
+
+登録したフォントは DOCX、XLSX、PPTX の変換で使用されます。登録内容は
+プロセス全体で共有されるため、別のフォントセットを設定する前にクリアしてください。
 
 ### Python
 

--- a/documents/README.ko.md
+++ b/documents/README.ko.md
@@ -34,7 +34,7 @@ MiniPdf는 런타임에 Microsoft Office, LibreOffice, Adobe Acrobat 또는 COM 
 |---|---|---|---|---|---|
 | .NET | XLSX, DOCX, PPTX | 라이브러리, CLI, Native AOT 바이너리 | 안정 | **[.NET 가이드](README.nuget.md)** | **[XLSX](../tests/MiniPdf.Benchmark/reports/comparison_report.md)**<br>**[DOCX](../tests/MiniPdf.Benchmark/reports_docx/comparison_report.md)**<br>**[PPTX](../tests/Issue_Files/reports_pptx/comparison_report.md)** |
 | Rust | XLSX, DOCX, PPTX | Crate, CLI | 실험적 | **[Rust 가이드](../minipdf-rs/README.md)** | **[XLSX](../artifacts/rust-benchmark/classic/xlsx/report/comparison_report.md)**<br>**[DOCX](../artifacts/rust-benchmark/classic/docx/report/comparison_report.md)** |
-| Java | XLSX, DOCX | 라이브러리, CLI | 실험적 | **[Java 소스](../minipdf-java/)** | **[XLSX](../artifacts/java-benchmark/issue/xlsx/report/comparison_report.md)** |
+| Java | XLSX, DOCX, PPTX | 라이브러리, CLI | 실험적 | **[Java 소스](../minipdf-java/)** | **[XLSX](../artifacts/java-benchmark/issue/xlsx/report/comparison_report.md)** |
 | Python | DOCX | 패키지, CLI | 실험적 | **[Python 가이드](../minipdf-python/README.md)** | **[XLSX](../artifacts/python-benchmark/issue/xlsx/report/comparison_report.md)** |
 | Node.js | XLSX, DOCX, PPTX | 네이티브 패키지 | 실험적 | **[Node.js 가이드](../minipdf-node/README.md)** | **[XLSX](../artifacts/node-benchmark/issue/xlsx/report/comparison_report.md)** |
 | Go | XLSX, DOCX, PPTX | 패키지, CLI | 실험적 | **[Go 가이드](../minipdf-go/README.md)** | **[XLSX](../artifacts/go-benchmark/issue/xlsx/report/comparison_report.md)** |
@@ -98,11 +98,14 @@ import io.github.minisoftware.minipdf.MiniPdf;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-MiniPdf.registerFont(
-		"Noto Sans",
-		Files.readAllBytes(Path.of("fonts/NotoSans-Regular.ttf")));
-MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
-MiniPdf.clearRegisteredFonts();
+try {
+	MiniPdf.registerFont(
+			"Noto Sans",
+			Files.readAllBytes(Path.of("fonts/NotoSans-Regular.ttf")));
+	MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
+} finally {
+	MiniPdf.clearRegisteredFonts();
+}
 ```
 
 등록한 글꼴은 DOCX, XLSX 및 PPTX 변환에 사용됩니다. 등록 내용은 프로세스

--- a/documents/README.ko.md
+++ b/documents/README.ko.md
@@ -85,7 +85,7 @@ minipdf report.docx -o report.pdf
 <dependency>
 	<groupId>io.github.mini-software</groupId>
 	<artifactId>minipdf</artifactId>
-	<version>0.1.5</version>
+	<version>0.1.6</version>
 </dependency>
 ```
 
@@ -95,10 +95,18 @@ Maven `groupId`에는 하이픈을 사용할 수 있지만 Java 패키지 이름
 
 ```java
 import io.github.minisoftware.minipdf.MiniPdf;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
+MiniPdf.registerFont(
+		"Noto Sans",
+		Files.readAllBytes(Path.of("fonts/NotoSans-Regular.ttf")));
 MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
+MiniPdf.clearRegisteredFonts();
 ```
+
+등록한 글꼴은 DOCX, XLSX 및 PPTX 변환에 사용됩니다. 등록 내용은 프로세스
+전체에서 공유되므로 다른 글꼴 세트를 구성하기 전에 지우십시오.
 
 ### Python
 

--- a/documents/README.zh-CN.md
+++ b/documents/README.zh-CN.md
@@ -34,7 +34,7 @@ MiniPdf 无需在运行时安装 Microsoft Office、LibreOffice、Adobe Acrobat 
 |---|---|---|---|---|---|
 | .NET | XLSX、DOCX、PPTX | 库、CLI、Native AOT 二进制文件 | 稳定 | **[.NET 指南](README.nuget.md)** | **[XLSX](../tests/MiniPdf.Benchmark/reports/comparison_report.md)**<br>**[DOCX](../tests/MiniPdf.Benchmark/reports_docx/comparison_report.md)**<br>**[PPTX](../tests/Issue_Files/reports_pptx/comparison_report.md)** |
 | Rust | XLSX、DOCX、PPTX | Crate、CLI | 实验性 | **[Rust 指南](../minipdf-rs/README.md)** | **[XLSX](../artifacts/rust-benchmark/classic/xlsx/report/comparison_report.md)**<br>**[DOCX](../artifacts/rust-benchmark/classic/docx/report/comparison_report.md)** |
-| Java | XLSX、DOCX | 库、CLI | 实验性 | **[Java 源代码](../minipdf-java/)** | **[XLSX](../artifacts/java-benchmark/issue/xlsx/report/comparison_report.md)** |
+| Java | XLSX、DOCX、PPTX | 库、CLI | 实验性 | **[Java 源代码](../minipdf-java/)** | **[XLSX](../artifacts/java-benchmark/issue/xlsx/report/comparison_report.md)** |
 | Python | DOCX | 包、CLI | 实验性 | **[Python 指南](../minipdf-python/README.md)** | **[XLSX](../artifacts/python-benchmark/issue/xlsx/report/comparison_report.md)** |
 | Node.js | XLSX、DOCX、PPTX | 原生包 | 实验性 | **[Node.js 指南](../minipdf-node/README.md)** | **[XLSX](../artifacts/node-benchmark/issue/xlsx/report/comparison_report.md)** |
 | Go | XLSX、DOCX、PPTX | 包、CLI | 实验性 | **[Go 指南](../minipdf-go/README.md)** | **[XLSX](../artifacts/go-benchmark/issue/xlsx/report/comparison_report.md)** |
@@ -97,11 +97,14 @@ import io.github.minisoftware.minipdf.MiniPdf;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-MiniPdf.registerFont(
-		"Noto Sans",
-		Files.readAllBytes(Path.of("fonts/NotoSans-Regular.ttf")));
-MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
-MiniPdf.clearRegisteredFonts();
+try {
+	MiniPdf.registerFont(
+			"Noto Sans",
+			Files.readAllBytes(Path.of("fonts/NotoSans-Regular.ttf")));
+	MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
+} finally {
+	MiniPdf.clearRegisteredFonts();
+}
 ```
 
 注册字体会用于 DOCX、XLSX 和 PPTX 转换。注册信息在整个进程中共享；配置

--- a/documents/README.zh-CN.md
+++ b/documents/README.zh-CN.md
@@ -85,7 +85,7 @@ minipdf report.docx -o report.pdf
 <dependency>
 	<groupId>io.github.mini-software</groupId>
 	<artifactId>minipdf</artifactId>
-	<version>0.1.5</version>
+	<version>0.1.6</version>
 </dependency>
 ```
 
@@ -94,10 +94,18 @@ Maven `groupId` 可以包含连字符，但 Java 包名不能。因此依赖坐�
 
 ```java
 import io.github.minisoftware.minipdf.MiniPdf;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
+MiniPdf.registerFont(
+		"Noto Sans",
+		Files.readAllBytes(Path.of("fonts/NotoSans-Regular.ttf")));
 MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
+MiniPdf.clearRegisteredFonts();
 ```
+
+注册字体会用于 DOCX、XLSX 和 PPTX 转换。注册信息在整个进程中共享；配置
+另一组字体前请先清除现有注册信息。
 
 ### Python
 

--- a/documents/README.zh-TW.md
+++ b/documents/README.zh-TW.md
@@ -34,7 +34,7 @@ MiniPdf 不需要在執行階段安裝 Microsoft Office、LibreOffice、Adobe Ac
 |---|---|---|---|---|---|
 | .NET | XLSX、DOCX、PPTX | 程式庫、CLI、Native AOT 二進位檔 | 穩定 | **[.NET 指南](README.nuget.md)** | **[XLSX](../tests/MiniPdf.Benchmark/reports/comparison_report.md)**<br>**[DOCX](../tests/MiniPdf.Benchmark/reports_docx/comparison_report.md)**<br>**[PPTX](../tests/Issue_Files/reports_pptx/comparison_report.md)** |
 | Rust | XLSX、DOCX、PPTX | Crate、CLI | 實驗性 | **[Rust 指南](../minipdf-rs/README.md)** | **[XLSX](../artifacts/rust-benchmark/classic/xlsx/report/comparison_report.md)**<br>**[DOCX](../artifacts/rust-benchmark/classic/docx/report/comparison_report.md)** |
-| Java | XLSX、DOCX | 程式庫、CLI | 實驗性 | **[Java 原始碼](../minipdf-java/)** | **[XLSX](../artifacts/java-benchmark/issue/xlsx/report/comparison_report.md)** |
+| Java | XLSX、DOCX、PPTX | 程式庫、CLI | 實驗性 | **[Java 原始碼](../minipdf-java/)** | **[XLSX](../artifacts/java-benchmark/issue/xlsx/report/comparison_report.md)** |
 | Python | DOCX | 套件、CLI | 實驗性 | **[Python 指南](../minipdf-python/README.md)** | **[XLSX](../artifacts/python-benchmark/issue/xlsx/report/comparison_report.md)** |
 | Node.js | XLSX、DOCX、PPTX | 原生套件 | 實驗性 | **[Node.js 指南](../minipdf-node/README.md)** | **[XLSX](../artifacts/node-benchmark/issue/xlsx/report/comparison_report.md)** |
 | Go | XLSX、DOCX、PPTX | 套件、CLI | 實驗性 | **[Go 指南](../minipdf-go/README.md)** | **[XLSX](../artifacts/go-benchmark/issue/xlsx/report/comparison_report.md)** |
@@ -97,11 +97,14 @@ import io.github.minisoftware.minipdf.MiniPdf;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-MiniPdf.registerFont(
-		"Noto Sans",
-		Files.readAllBytes(Path.of("fonts/NotoSans-Regular.ttf")));
-MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
-MiniPdf.clearRegisteredFonts();
+try {
+	MiniPdf.registerFont(
+			"Noto Sans",
+			Files.readAllBytes(Path.of("fonts/NotoSans-Regular.ttf")));
+	MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
+} finally {
+	MiniPdf.clearRegisteredFonts();
+}
 ```
 
 註冊字型會用於 DOCX、XLSX 和 PPTX 轉換。註冊資訊在整個處理程序中共用；

--- a/documents/README.zh-TW.md
+++ b/documents/README.zh-TW.md
@@ -85,7 +85,7 @@ minipdf report.docx -o report.pdf
 <dependency>
 	<groupId>io.github.mini-software</groupId>
 	<artifactId>minipdf</artifactId>
-	<version>0.1.5</version>
+	<version>0.1.6</version>
 </dependency>
 ```
 
@@ -94,10 +94,18 @@ Maven `groupId` 可以包含連字號，但 Java 套件名稱不能。因此相�
 
 ```java
 import io.github.minisoftware.minipdf.MiniPdf;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
+MiniPdf.registerFont(
+		"Noto Sans",
+		Files.readAllBytes(Path.of("fonts/NotoSans-Regular.ttf")));
 MiniPdf.convertToPdf(Path.of("report.docx"), Path.of("report.pdf"));
+MiniPdf.clearRegisteredFonts();
 ```
+
+註冊字型會用於 DOCX、XLSX 和 PPTX 轉換。註冊資訊在整個處理程序中共用；
+設定另一組字型前請先清除現有註冊資訊。
 
 ### Python
 

--- a/minipdf-java/README.md
+++ b/minipdf-java/README.md
@@ -39,6 +39,7 @@ that are not available in the standard PDF fonts:
 
 ```java
 import java.nio.file.Files;
+import java.nio.file.Path;
 
 MiniPdf.registerFont(
   "Noto Sans",

--- a/minipdf-java/README.md
+++ b/minipdf-java/README.md
@@ -11,7 +11,7 @@ The library is available from Maven Central:
 <dependency>
     <groupId>io.github.mini-software</groupId>
     <artifactId>minipdf</artifactId>
-    <version>0.1.5</version>
+    <version>0.1.6</version>
 </dependency>
 ```
 
@@ -34,20 +34,38 @@ MiniPdf.convertToPdf(
 Use `MiniPdf.convertBytesToPdf` when the Office document is already in memory.
 `ConversionOptions.withPageSize` overrides the output page size.
 
+Register fonts before converting when DOCX, XLSX, or PPTX content needs glyphs
+that are not available in the standard PDF fonts:
+
+```java
+import java.nio.file.Files;
+
+MiniPdf.registerFont(
+  "Noto Sans",
+  Files.readAllBytes(Path.of("fonts/NotoSans-Regular.ttf")));
+MiniPdf.convertToPdf(
+  Path.of("document.docx"),
+  Path.of("document.pdf"));
+MiniPdf.clearRegisteredFonts();
+```
+
+Registered fonts are process-wide. `clearRegisteredFonts` removes them when the
+same process needs a different font set for a later conversion.
+
 ## CLI
 
 Download the executable JAR with Maven:
 
 ```powershell
 mvn dependency:copy `
-  -Dartifact=io.github.mini-software:minipdf-cli:0.1.5 `
+  -Dartifact=io.github.mini-software:minipdf-cli:0.1.6 `
   -DoutputDirectory=.
 ```
 
 Convert a document:
 
 ```powershell
-java -jar minipdf-cli-0.1.5.jar input.pptx -o output.pdf
+java -jar minipdf-cli-0.1.6.jar input.pptx -o output.pdf
 ```
 
 The CLI accepts `.docx`, `.xlsx`, and `.pptx` files. Run it with `--help` for

--- a/minipdf-java/README.md
+++ b/minipdf-java/README.md
@@ -41,13 +41,16 @@ that are not available in the standard PDF fonts:
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-MiniPdf.registerFont(
-  "Noto Sans",
-  Files.readAllBytes(Path.of("fonts/NotoSans-Regular.ttf")));
-MiniPdf.convertToPdf(
-  Path.of("document.docx"),
-  Path.of("document.pdf"));
-MiniPdf.clearRegisteredFonts();
+try {
+    MiniPdf.registerFont(
+            "Noto Sans",
+            Files.readAllBytes(Path.of("fonts/NotoSans-Regular.ttf")));
+    MiniPdf.convertToPdf(
+            Path.of("document.docx"),
+            Path.of("document.pdf"));
+} finally {
+    MiniPdf.clearRegisteredFonts();
+}
 ```
 
 Registered fonts are process-wide. `clearRegisteredFonts` removes them when the

--- a/minipdf-java/minipdf-cli/pom.xml
+++ b/minipdf-java/minipdf-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.mini-software</groupId>
         <artifactId>minipdf-java-parent</artifactId>
-        <version>0.1.5</version>
+        <version>0.1.6</version>
     </parent>
 
     <artifactId>minipdf-cli</artifactId>

--- a/minipdf-java/minipdf-cli/src/main/java/io/github/minisoftware/minipdf/cli/MiniPdfCommand.java
+++ b/minipdf-java/minipdf-cli/src/main/java/io/github/minisoftware/minipdf/cli/MiniPdfCommand.java
@@ -20,7 +20,7 @@ import java.util.concurrent.Callable;
 
 @Command(
         name = "minipdf",
-    version = "minipdf-java 0.1.5",
+    version = "minipdf-java 0.1.6",
     description = "Convert XLSX, DOCX, and PPTX files to PDF with the Java MiniPdf engine.",
         mixinStandardHelpOptions = true,
         subcommands = MiniPdfCommand.ConvertCommand.class)

--- a/minipdf-java/minipdf/pom.xml
+++ b/minipdf-java/minipdf/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.mini-software</groupId>
         <artifactId>minipdf-java-parent</artifactId>
-        <version>0.1.5</version>
+        <version>0.1.6</version>
     </parent>
 
     <artifactId>minipdf</artifactId>

--- a/minipdf-java/minipdf/src/main/java/io/github/minisoftware/minipdf/MiniPdf.java
+++ b/minipdf-java/minipdf/src/main/java/io/github/minisoftware/minipdf/MiniPdf.java
@@ -29,6 +29,10 @@ public final class MiniPdf {
         return List.copyOf(REGISTERED_FONTS);
     }
 
+    public static void clearRegisteredFonts() {
+        REGISTERED_FONTS.clear();
+    }
+
     public static OfficeFormat detectOfficeFormat(byte[] input) throws MiniPdfException {
         return OfficePackageDetector.detect(Objects.requireNonNull(input, "input"));
     }

--- a/minipdf-java/minipdf/src/main/java/io/github/minisoftware/minipdf/internal/SimplePdfTextRenderer.java
+++ b/minipdf-java/minipdf/src/main/java/io/github/minisoftware/minipdf/internal/SimplePdfTextRenderer.java
@@ -1,11 +1,23 @@
 package io.github.minisoftware.minipdf.internal;
 
 import io.github.minisoftware.minipdf.ConversionOptions;
+import io.github.minisoftware.minipdf.MiniPdf;
+import io.github.minisoftware.minipdf.MiniPdfException;
 import io.github.minisoftware.minipdf.PageSize;
 import io.github.minisoftware.minipdf.PdfColor;
 import io.github.minisoftware.minipdf.PdfDocument;
 import io.github.minisoftware.minipdf.PdfPage;
+import io.github.minisoftware.minipdf.RegisteredFont;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.font.PDFont;
+import org.apache.pdfbox.pdmodel.font.PDType0Font;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,15 +29,20 @@ public final class SimplePdfTextRenderer {
     private SimplePdfTextRenderer() {
     }
 
-    public static byte[] render(List<String> sourceLines, ConversionOptions options) {
+    public static byte[] render(List<String> sourceLines, ConversionOptions options) throws MiniPdfException {
         return renderPages(List.of(sourceLines), options, PageSize.A4);
     }
 
     public static byte[] renderPages(
             List<List<String>> sourcePages,
             ConversionOptions options,
-            PageSize defaultPageSize) {
+            PageSize defaultPageSize) throws MiniPdfException {
         PageSize size = options.pageSize().orElse(defaultPageSize);
+        byte[] registeredFontPdf = renderWithRegisteredFont(sourcePages, size);
+        if (registeredFontPdf != null) {
+            return registeredFontPdf;
+        }
+
         PdfDocument document = new PdfDocument();
         int maxCharacters = Math.max(1, (int) ((size.width() - MARGIN * 2.0f) / (FONT_SIZE * 0.52f)));
 
@@ -44,6 +61,89 @@ public final class SimplePdfTextRenderer {
             }
         }
         return document.toBytes();
+    }
+
+    private static byte[] renderWithRegisteredFont(List<List<String>> sourcePages, PageSize size)
+            throws MiniPdfException {
+        if (MiniPdf.registeredFonts().isEmpty()) {
+            return null;
+        }
+
+        try (PDDocument document = new PDDocument()) {
+            PDFont font = loadFont(document, sourcePages);
+            if (font == null) {
+                return null;
+            }
+
+            int maxCharacters = Math.max(1, (int) ((size.width() - MARGIN * 2.0f) / (FONT_SIZE * 0.52f)));
+            for (List<String> sourcePage : sourcePages) {
+                PDPage page = addPage(document, size);
+                PDPageContentStream content = new PDPageContentStream(document, page);
+                float y = size.height() - MARGIN;
+                for (String sourceLine : sourcePage) {
+                    for (String line : wrap(sourceLine, maxCharacters)) {
+                        if (y < MARGIN) {
+                            content.close();
+                            page = addPage(document, size);
+                            content = new PDPageContentStream(document, page);
+                            y = size.height() - MARGIN;
+                        }
+                        content.beginText();
+                        content.setFont(font, FONT_SIZE);
+                        content.newLineAtOffset(MARGIN, y);
+                        content.showText(line);
+                        content.endText();
+                        y -= LINE_HEIGHT;
+                    }
+                }
+                content.close();
+            }
+
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            document.save(output);
+            return output.toByteArray();
+        } catch (IOException exception) {
+            throw new MiniPdfException(
+                    MiniPdfException.Kind.IO,
+                    "failed to render PDF with a registered font: " + exception.getMessage(),
+                    exception);
+        }
+    }
+
+    private static PDFont loadFont(PDDocument document, List<List<String>> sourcePages) {
+        for (RegisteredFont registeredFont : MiniPdf.registeredFonts()) {
+            try {
+                PDFont font = PDType0Font.load(
+                        document,
+                        new ByteArrayInputStream(registeredFont.data()),
+                        true);
+                if (supports(font, sourcePages)) {
+                    return font;
+                }
+            } catch (IOException | IllegalArgumentException ignored) {
+                // Try the next registered font.
+            }
+        }
+        return null;
+    }
+
+    private static boolean supports(PDFont font, List<List<String>> sourcePages) {
+        try {
+            for (List<String> sourcePage : sourcePages) {
+                for (String line : sourcePage) {
+                    font.getStringWidth(line);
+                }
+            }
+            return true;
+        } catch (IOException | IllegalArgumentException exception) {
+            return false;
+        }
+    }
+
+    private static PDPage addPage(PDDocument document, PageSize size) {
+        PDPage page = new PDPage(new PDRectangle(size.width(), size.height()));
+        document.addPage(page);
+        return page;
     }
 
     private static List<String> wrap(String value, int maxCharacters) {

--- a/minipdf-java/minipdf/src/main/java/io/github/minisoftware/minipdf/internal/SimplePdfTextRenderer.java
+++ b/minipdf-java/minipdf/src/main/java/io/github/minisoftware/minipdf/internal/SimplePdfTextRenderer.java
@@ -79,24 +79,31 @@ public final class SimplePdfTextRenderer {
             for (List<String> sourcePage : sourcePages) {
                 PDPage page = addPage(document, size);
                 PDPageContentStream content = new PDPageContentStream(document, page);
-                float y = size.height() - MARGIN;
-                for (String sourceLine : sourcePage) {
-                    for (String line : wrap(sourceLine, maxCharacters)) {
-                        if (y < MARGIN) {
-                            content.close();
-                            page = addPage(document, size);
-                            content = new PDPageContentStream(document, page);
-                            y = size.height() - MARGIN;
+                try {
+                    float y = size.height() - MARGIN;
+                    for (String sourceLine : sourcePage) {
+                        for (String line : wrap(sourceLine, maxCharacters)) {
+                            if (y < MARGIN) {
+                                PDPageContentStream completedContent = content;
+                                content = null;
+                                completedContent.close();
+                                page = addPage(document, size);
+                                content = new PDPageContentStream(document, page);
+                                y = size.height() - MARGIN;
+                            }
+                            content.beginText();
+                            content.setFont(font, FONT_SIZE);
+                            content.newLineAtOffset(MARGIN, y);
+                            content.showText(line);
+                            content.endText();
+                            y -= LINE_HEIGHT;
                         }
-                        content.beginText();
-                        content.setFont(font, FONT_SIZE);
-                        content.newLineAtOffset(MARGIN, y);
-                        content.showText(line);
-                        content.endText();
-                        y -= LINE_HEIGHT;
+                    }
+                } finally {
+                    if (content != null) {
+                        content.close();
                     }
                 }
-                content.close();
             }
 
             ByteArrayOutputStream output = new ByteArrayOutputStream();

--- a/minipdf-java/minipdf/src/test/java/io/github/minisoftware/minipdf/BasicOfficeConversionTest.java
+++ b/minipdf-java/minipdf/src/test/java/io/github/minisoftware/minipdf/BasicOfficeConversionTest.java
@@ -1,9 +1,17 @@
 package io.github.minisoftware.minipdf;
 
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.font.PDFont;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -12,6 +20,8 @@ import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -19,6 +29,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class BasicOfficeConversionTest {
     @TempDir
     Path temporaryDirectory;
+
+    @AfterEach
+    void clearRegisteredFonts() {
+        MiniPdf.clearRegisteredFonts();
+    }
 
     @Test
     void convertsBasicDocxText() throws Exception {
@@ -31,6 +46,18 @@ class BasicOfficeConversionTest {
 
         assertTrue(pdf.startsWith("%PDF-1.4"));
         assertTrue(pdf.contains("(Hello DOCX) Tj"));
+    }
+
+    @Test
+    void usesRegisteredFontForDocxUnicodeText() throws Exception {
+        String text = "\u041f\u0440\u0438\u0432\u0435\u0442 DOCX";
+        registerTestFont();
+        byte[] docx = packageWith(Map.of(
+                "word/document.xml",
+                "<w:document xmlns:w=\"urn:w\"><w:body><w:p><w:r><w:t>" + text
+                        + "</w:t></w:r></w:p></w:body></w:document>"));
+
+        assertUnicodeTextUsesEmbeddedFont(MiniPdf.convertBytesToPdf(docx), text);
     }
 
     @Test
@@ -91,6 +118,47 @@ class BasicOfficeConversionTest {
         assertTrue(pdf.contains("/Count 2"));
         assertTrue(pdf.indexOf("(First) Tj") < pdf.indexOf("(Second) Tj"));
         assertTrue(!pdf.contains("(Orphan) Tj"));
+    }
+
+    @Test
+    void usesRegisteredFontForPptxUnicodeText() throws Exception {
+        String text = "\u041f\u0440\u0438\u0432\u0435\u0442 PPTX";
+        registerTestFont();
+        Map<String, String> entries = new LinkedHashMap<>();
+        entries.put("ppt/presentation.xml",
+                "<p:presentation xmlns:p=\"urn:p\" xmlns:r=\"urn:r\"><p:sldIdLst>"
+                        + "<p:sldId r:id=\"rId1\"/></p:sldIdLst></p:presentation>");
+        entries.put("ppt/_rels/presentation.xml.rels",
+                "<Relationships><Relationship Id=\"rId1\" Type=\"urn/slide\" "
+                        + "Target=\"slides/slide1.xml\"/></Relationships>");
+        entries.put("ppt/slides/slide1.xml",
+                "<p:sld xmlns:p=\"urn:p\" xmlns:a=\"urn:a\"><a:p><a:r><a:t>" + text
+                        + "</a:t></a:r></a:p></p:sld>");
+
+        assertUnicodeTextUsesEmbeddedFont(MiniPdf.convertBytesToPdf(packageWith(entries)), text);
+    }
+
+    private static void registerTestFont() throws Exception {
+        try (InputStream input = PDFont.class.getResourceAsStream(
+                "/org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf")) {
+            assertNotNull(input);
+            MiniPdf.registerFont("Liberation Sans", input.readAllBytes());
+        }
+    }
+
+    private static void assertUnicodeTextUsesEmbeddedFont(byte[] pdf, String expected) throws Exception {
+        try (PDDocument document = Loader.loadPDF(pdf)) {
+            assertEquals(expected, new PDFTextStripper().getText(document).trim());
+            boolean hasEmbeddedFont = false;
+            for (PDPage page : document.getPages()) {
+                for (COSName fontName : page.getResources().getFontNames()) {
+                    if (page.getResources().getFont(fontName).isEmbedded()) {
+                        hasEmbeddedFont = true;
+                    }
+                }
+            }
+            assertTrue(hasEmbeddedFont);
+        }
     }
 
     @Test

--- a/minipdf-java/minipdf/src/test/java/io/github/minisoftware/minipdf/FontRegistrationTest.java
+++ b/minipdf-java/minipdf/src/test/java/io/github/minisoftware/minipdf/FontRegistrationTest.java
@@ -1,5 +1,6 @@
 package io.github.minisoftware.minipdf;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
@@ -8,6 +9,11 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class FontRegistrationTest {
+    @AfterEach
+    void clearRegisteredFonts() {
+        MiniPdf.clearRegisteredFonts();
+    }
+
     @Test
     void registrationDefensivelyCopiesFontData() {
         byte[] data = {1, 2, 3};

--- a/minipdf-java/pom.xml
+++ b/minipdf-java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.mini-software</groupId>
     <artifactId>minipdf-java-parent</artifactId>
-    <version>0.1.5</version>
+    <version>0.1.6</version>
     <packaging>pom</packaging>
 
     <name>MiniPdf for Java</name>


### PR DESCRIPTION
Fix Java DOCX and PPTX conversion so `MiniPdf.registerFont(...)` is honored by the shared text renderer instead of falling back to Windows-1252 Helvetica.

## Changes

- Render DOCX and PPTX text with an embedded registered Type 0 font when it covers the document text
- Skip invalid or unsuitable registrations and preserve the legacy fallback when no usable font is available
- Add `MiniPdf.clearRegisteredFonts()` for process-wide font lifecycle management
- Add DOCX and PPTX Unicode/embedded-font regression tests
- Bump the Java Maven artifacts and CLI version to `0.1.6`
- Update the Java guide and all translated README files

## Validation

- `mvn -B -ntp clean verify`
- 3 reactor modules succeeded
- 41 tests passed, 0 failures, 0 errors, 0 skipped

Fixes #151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for registering custom fonts for document conversions.
  - Added the ability to clear registered fonts and configure different font sets.
  - Registered fonts support Unicode text in DOCX, XLSX, and PPTX conversions and are shared process-wide.
  - Added Java support for PPTX input conversion.
  - Updated Java examples to demonstrate font registration and reliable cleanup.

- **Documentation**
  - Updated Java dependency and CLI version references to 0.1.6.
  - Added guidance for using custom fonts and managing registered font settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->