### PR TITLE
Render behindDoc wpg group fills when a child shape carries a text box

### DIFF
--- a/src/MiniPdf/DocxReader.cs
+++ b/src/MiniPdf/DocxReader.cs
@@ -1370,9 +1370,10 @@ internal static class DocxReader
                 }
 
                 // Check for inline images in the run
+                var runDrawing = child.Descendants(W + "drawing").FirstOrDefault();
                 var drawing = child.Descendants(W + "txbxContent").Any()
                     ? null
-                    : child.Descendants(W + "drawing").FirstOrDefault();
+                    : runDrawing;
                 if (drawing != null)
                 {
                     var image = ReadImage(drawing, relationships, archive);
@@ -1381,6 +1382,14 @@ internal static class DocxReader
 
                     // Check for anchor shapes (filled rectangles without image blip)
                     shapes.AddRange(ReadAnchorShapes(drawing, themeColors));
+                }
+                else if (runDrawing?.Element(WP + "anchor")?.Element(A + "graphic")
+                             ?.Element(A + "graphicData")?.Element(WPG + "wgp") != null)
+                {
+                    // A wpg group keeps its child fills even when one child carries a
+                    // text box: the floating text box path skips fill extraction for
+                    // groups (anchorHasGroupShape), so the group shapes are read here.
+                    shapes.AddRange(ReadAnchorShapes(runDrawing, themeColors));
                 }
             }
             else if (child.Name == W + "hyperlink")

--- a/src/MiniPdf/DocxReader.cs
+++ b/src/MiniPdf/DocxReader.cs
@@ -822,6 +822,10 @@ internal static class DocxReader
             compatibilityMode);
     }
 
+    /// <summary>
+    /// Splits a VML style attribute (semicolon-separated name:value pairs) into a
+    /// case-insensitive dictionary.
+    /// </summary>
     private static Dictionary<string, string> ParseVmlStyle(string? style)
     {
         var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -838,6 +842,9 @@ internal static class DocxReader
         return values;
     }
 
+    /// <summary>
+    /// Returns the named VML style value in points when it carries a pt suffix, otherwise 0.
+    /// </summary>
     private static float ParseVmlPointLength(Dictionary<string, string> style, string name)
     {
         if (!style.TryGetValue(name, out var value) || !value.EndsWith("pt", StringComparison.OrdinalIgnoreCase))

--- a/src/MiniPdf/DocxReader.cs
+++ b/src/MiniPdf/DocxReader.cs
@@ -1381,27 +1381,29 @@ internal static class DocxReader
                         runs.Add(run);
                 }
 
-                // Check for inline images in the run
-                var runDrawing = child.Descendants(W + "drawing").FirstOrDefault();
-                var drawing = child.Descendants(W + "txbxContent").Any()
-                    ? null
-                    : runDrawing;
-                if (drawing != null)
+                // Process each drawing owned by this run independently. Drawings owned by
+                // nested text box runs are parsed with their containing paragraphs.
+                foreach (var runDrawing in child.Descendants(W + "drawing")
+                             .Where(candidate => ReferenceEquals(
+                                 candidate.Ancestors(W + "r").FirstOrDefault(), child)))
                 {
-                    var image = ReadImage(drawing, relationships, archive);
-                    if (image != null)
-                        images.Add(image);
+                    if (!runDrawing.Descendants(W + "txbxContent").Any())
+                    {
+                        var image = ReadImage(runDrawing, relationships, archive);
+                        if (image != null)
+                            images.Add(image);
 
-                    // Check for anchor shapes (filled rectangles without image blip)
-                    shapes.AddRange(ReadAnchorShapes(drawing, themeColors));
-                }
-                else if (runDrawing?.Element(WP + "anchor")?.Element(A + "graphic")
-                             ?.Element(A + "graphicData")?.Element(WPG + "wgp") != null)
-                {
-                    // A wpg group keeps its child fills even when one child carries a
-                    // text box: the floating text box path skips fill extraction for
-                    // groups (anchorHasGroupShape), so the group shapes are read here.
-                    shapes.AddRange(ReadAnchorShapes(runDrawing, themeColors));
+                        // Check for anchor shapes (filled rectangles without image blip)
+                        shapes.AddRange(ReadAnchorShapes(runDrawing, themeColors));
+                    }
+                    else if (runDrawing.Element(WP + "anchor")?.Element(A + "graphic")
+                                 ?.Element(A + "graphicData")?.Element(WPG + "wgp") != null)
+                    {
+                        // A wpg group keeps its child fills even when one child carries a
+                        // text box: the floating text box path skips fill extraction for
+                        // groups (anchorHasGroupShape), so the group shapes are read here.
+                        shapes.AddRange(ReadAnchorShapes(runDrawing, themeColors));
+                    }
                 }
             }
             else if (child.Name == W + "hyperlink")

--- a/src/MiniPdf/DocxReader.cs
+++ b/src/MiniPdf/DocxReader.cs
@@ -846,6 +846,11 @@ internal static class DocxReader
             System.Globalization.CultureInfo.InvariantCulture, out var points) ? points : 0;
     }
 
+    /// <summary>
+    /// Reads a single w:p element into a DocxParagraph: resolved paragraph and run properties,
+    /// numbering, inline and anchored images, behindDoc anchor shapes (including wpg groups)
+    /// and floating text boxes.
+    /// </summary>
     private static DocxParagraph? ReadParagraph(XElement pElement, Dictionary<string, DocxStyleInfo> styles,
         Dictionary<string, DocxNumberingDef> numbering, Dictionary<string, string> relationships, ZipArchive archive,
         Dictionary<string, string>? themeColors = null, string? defaultLatinFontName = null, string? defaultEastAsiaFontName = null)

--- a/tests/MiniPdf.Tests/DocxDrawingTests.cs
+++ b/tests/MiniPdf.Tests/DocxDrawingTests.cs
@@ -1,0 +1,119 @@
+using System.IO.Compression;
+using System.Text;
+
+namespace MiniSoftware.Tests;
+
+/// <summary>
+/// Covers DrawingML parsing behavior that is independent of repository issue fixtures.
+/// </summary>
+public class DocxDrawingTests
+{
+    /// <summary>
+    /// A run containing multiple drawings must process each drawing independently when a later
+    /// grouped drawing carries text box content.
+    /// </summary>
+    [Fact]
+    public void Read_MultipleDrawingsInTextBoxHostRun_ReadsEachTopLevelDrawing()
+    {
+        using var stream = CreateDocxWithMultipleDrawingsAndGroupTextBox();
+
+        var document = DocxReader.Read(stream);
+        var shapes = document.Elements
+            .OfType<DocxParagraph>()
+            .SelectMany(paragraph => paragraph.Shapes ?? [])
+            .ToArray();
+
+        Assert.Equal(2, shapes.Length);
+        Assert.Contains(shapes, shape => shape.FillColor.R > 0.99f && shape.FillColor.B < 0.01f);
+        Assert.Contains(shapes, shape => shape.FillColor.B > 0.99f && shape.FillColor.R < 0.01f);
+    }
+
+    /// <summary>
+    /// Creates a minimal DOCX whose single run has a simple shape followed by a grouped shape
+    /// with an empty text box.
+    /// </summary>
+    private static MemoryStream CreateDocxWithMultipleDrawingsAndGroupTextBox()
+    {
+        var stream = new MemoryStream();
+        using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            AddEntry(archive, "[Content_Types].xml",
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+                  <Default Extension="xml" ContentType="application/xml"/>
+                  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+                  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+                </Types>
+                """);
+            AddEntry(archive, "_rels/.rels",
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+                  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+                </Relationships>
+                """);
+            AddEntry(archive, "word/document.xml",
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+                            xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+                            xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+                            xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup"
+                            xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">
+                  <w:body>
+                    <w:p>
+                      <w:r>
+                        <w:drawing>
+                          <wp:anchor behindDoc="1">
+                            <wp:positionH relativeFrom="page"><wp:posOffset>0</wp:posOffset></wp:positionH>
+                            <wp:positionV relativeFrom="page"><wp:posOffset>0</wp:posOffset></wp:positionV>
+                            <wp:extent cx="914400" cy="914400"/>
+                            <a:graphic><a:graphicData><wps:wsp><wps:spPr>
+                              <a:solidFill><a:srgbClr val="FF0000"/></a:solidFill>
+                              <a:prstGeom prst="rect"/>
+                            </wps:spPr></wps:wsp></a:graphicData></a:graphic>
+                          </wp:anchor>
+                        </w:drawing>
+                        <w:drawing>
+                          <wp:anchor behindDoc="1">
+                            <wp:positionH relativeFrom="page"><wp:posOffset>914400</wp:posOffset></wp:positionH>
+                            <wp:positionV relativeFrom="page"><wp:posOffset>0</wp:posOffset></wp:positionV>
+                            <wp:extent cx="914400" cy="914400"/>
+                            <a:graphic><a:graphicData><wpg:wgp>
+                              <wpg:grpSpPr><a:xfrm>
+                                <a:off x="0" y="0"/><a:ext cx="914400" cy="914400"/>
+                                <a:chOff x="0" y="0"/><a:chExt cx="914400" cy="914400"/>
+                              </a:xfrm></wpg:grpSpPr>
+                              <wps:wsp>
+                                <wps:spPr>
+                                  <a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="914400"/></a:xfrm>
+                                  <a:solidFill><a:srgbClr val="0000FF"/></a:solidFill>
+                                  <a:prstGeom prst="rect"/>
+                                </wps:spPr>
+                                <wps:txbx><w:txbxContent><w:p/></w:txbxContent></wps:txbx>
+                              </wps:wsp>
+                            </wpg:wgp></a:graphicData></a:graphic>
+                          </wp:anchor>
+                        </w:drawing>
+                      </w:r>
+                    </w:p>
+                  </w:body>
+                </w:document>
+                """);
+        }
+
+        stream.Position = 0;
+        return stream;
+    }
+
+    /// <summary>
+    /// Adds a UTF-8 XML part to a DOCX archive.
+    /// </summary>
+    private static void AddEntry(ZipArchive archive, string path, string content)
+    {
+        var entry = archive.CreateEntry(path);
+        using var writer = new StreamWriter(entry.Open(), Encoding.UTF8);
+        writer.Write(content);
+    }
+}

--- a/tests/MiniPdf.Tests/DocxIssueFileTests.cs
+++ b/tests/MiniPdf.Tests/DocxIssueFileTests.cs
@@ -4,6 +4,40 @@ namespace MiniSoftware.Tests;
 
 public class DocxIssueFileTests
 {
+    /// <summary>
+    /// Fabrikam.docx: a behindDoc wpg group whose first rectangle carries an empty text box must
+    /// still render its page background, white rectangles and card outlines.
+    /// </summary>
+    [Fact]
+    public void Fabrikam_BehindDocGroupWithTextBox_RendersGroupFills()
+    {
+        var issuePath = FindIssueDocx("Fabrikam.docx");
+
+        using var stream = File.OpenRead(issuePath);
+        var document = DocxToPdfConverter.Convert(stream);
+        var page = Assert.Single(document.Pages);
+
+        // The business-card sheet is one behindDoc wpg group: an accent1 (C0E3EC)
+        // page background, twenty bg1 (white) rectangles and ten stroke-only card
+        // outlines. Its first rectangle carries an empty text box, which must not
+        // suppress the group fills.
+        var background = Assert.Single(page.RectBlocks, rect =>
+            rect.Width >= page.Width - 0.5f && rect.Height >= page.Height - 0.5f);
+        Assert.InRange(background.X, -0.5f, 0.5f);
+        Assert.InRange(background.Y, -0.5f, 0.5f);
+        Assert.InRange(background.FillColor.R, 0.75f, 0.76f);
+        Assert.InRange(background.FillColor.G, 0.89f, 0.90f);
+        Assert.InRange(background.FillColor.B, 0.92f, 0.93f);
+
+        Assert.Equal(20, page.RectBlocks.Count(rect =>
+            rect.FillColor.R > 0.99f && rect.FillColor.G > 0.99f && rect.FillColor.B > 0.99f));
+        Assert.Equal(40, page.LineBlocks.Count);
+    }
+
+    /// <summary>
+    /// TestIssue78.docx: the header-table labels must share one right edge when measured with
+    /// their preferred font widths, and the date value must stay centered in its cell.
+    /// </summary>
     [Fact]
     public void Issue78_HeaderTable_UsesPreferredFontWidthsForAlignment()
     {
@@ -154,10 +188,6 @@ public class DocxIssueFileTests
         Assert.Contains("Bên B cam kết trả tiền", secondPageText, StringComparison.Ordinal);
     }
 
-    /// <summary>
-    /// TestIssue93.docx: the VML logo in a floating text box must stay on the right, and the
-    /// legacy table grid must keep its row spacing, yellow highlights and heading positions.
-    /// </summary>
     [Fact]
     public void Issue93_VmlImageAndLegacyTableGrid_PreserveLayout()
     {
@@ -212,39 +242,6 @@ public class DocxIssueFileTests
         Assert.InRange(projectTableRowBoundaries[1] - projectTableRowBoundaries[2], 12f, 14f);
     }
 
-    /// <summary>
-    /// Fabrikam.docx: a behindDoc wpg group whose first rectangle carries an empty text box must
-    /// still render its page background, white rectangles and card outlines.
-    /// </summary>
-    [Fact]
-    public void Fabrikam_BehindDocGroupWithTextBox_RendersGroupFills()
-    {
-        var issuePath = FindIssueDocx("Fabrikam.docx");
-
-        using var stream = File.OpenRead(issuePath);
-        var document = DocxToPdfConverter.Convert(stream);
-        var page = Assert.Single(document.Pages);
-
-        // The business-card sheet is one behindDoc wpg group: an accent1 (C0E3EC)
-        // page background, twenty bg1 (white) rectangles and ten stroke-only card
-        // outlines. Its first rectangle carries an empty text box, which must not
-        // suppress the group fills.
-        var background = Assert.Single(page.RectBlocks, rect =>
-            rect.Width >= page.Width - 0.5f && rect.Height >= page.Height - 0.5f);
-        Assert.InRange(background.X, -0.5f, 0.5f);
-        Assert.InRange(background.Y, -0.5f, 0.5f);
-        Assert.InRange(background.FillColor.R, 0.75f, 0.76f);
-        Assert.InRange(background.FillColor.G, 0.89f, 0.90f);
-        Assert.InRange(background.FillColor.B, 0.92f, 0.93f);
-
-        Assert.Equal(20, page.RectBlocks.Count(rect =>
-            rect.FillColor.R > 0.99f && rect.FillColor.G > 0.99f && rect.FillColor.B > 0.99f));
-        Assert.Equal(40, page.LineBlocks.Count);
-    }
-
-    /// <summary>
-    /// Locates a DOCX fixture under tests/Issue_Files/docx by walking up from the test output directory.
-    /// </summary>
     private static string FindIssueDocx(string fileName)
     {
         var directory = new DirectoryInfo(AppContext.BaseDirectory);

--- a/tests/MiniPdf.Tests/DocxIssueFileTests.cs
+++ b/tests/MiniPdf.Tests/DocxIssueFileTests.cs
@@ -208,6 +208,32 @@ public class DocxIssueFileTests
         Assert.InRange(projectTableRowBoundaries[1] - projectTableRowBoundaries[2], 12f, 14f);
     }
 
+    [Fact]
+    public void Fabrikam_BehindDocGroupWithTextBox_RendersGroupFills()
+    {
+        var issuePath = FindIssueDocx("Fabrikam.docx");
+
+        using var stream = File.OpenRead(issuePath);
+        var document = DocxToPdfConverter.Convert(stream);
+        var page = Assert.Single(document.Pages);
+
+        // The business-card sheet is one behindDoc wpg group: an accent1 (C0E3EC)
+        // page background, twenty bg1 (white) rectangles and ten stroke-only card
+        // outlines. Its first rectangle carries an empty text box, which must not
+        // suppress the group fills.
+        var background = Assert.Single(page.RectBlocks, rect =>
+            rect.Width >= page.Width - 0.5f && rect.Height >= page.Height - 0.5f);
+        Assert.InRange(background.X, -0.5f, 0.5f);
+        Assert.InRange(background.Y, -0.5f, 0.5f);
+        Assert.InRange(background.FillColor.R, 0.75f, 0.76f);
+        Assert.InRange(background.FillColor.G, 0.89f, 0.90f);
+        Assert.InRange(background.FillColor.B, 0.92f, 0.93f);
+
+        Assert.Equal(20, page.RectBlocks.Count(rect =>
+            rect.FillColor.R > 0.99f && rect.FillColor.G > 0.99f && rect.FillColor.B > 0.99f));
+        Assert.Equal(40, page.LineBlocks.Count);
+    }
+
     private static string FindIssueDocx(string fileName)
     {
         var directory = new DirectoryInfo(AppContext.BaseDirectory);

--- a/tests/MiniPdf.Tests/DocxIssueFileTests.cs
+++ b/tests/MiniPdf.Tests/DocxIssueFileTests.cs
@@ -154,6 +154,10 @@ public class DocxIssueFileTests
         Assert.Contains("Bên B cam kết trả tiền", secondPageText, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// TestIssue93.docx: the VML logo in a floating text box must stay on the right, and the
+    /// legacy table grid must keep its row spacing, yellow highlights and heading positions.
+    /// </summary>
     [Fact]
     public void Issue93_VmlImageAndLegacyTableGrid_PreserveLayout()
     {
@@ -208,6 +212,10 @@ public class DocxIssueFileTests
         Assert.InRange(projectTableRowBoundaries[1] - projectTableRowBoundaries[2], 12f, 14f);
     }
 
+    /// <summary>
+    /// Fabrikam.docx: a behindDoc wpg group whose first rectangle carries an empty text box must
+    /// still render its page background, white rectangles and card outlines.
+    /// </summary>
     [Fact]
     public void Fabrikam_BehindDocGroupWithTextBox_RendersGroupFills()
     {
@@ -234,6 +242,9 @@ public class DocxIssueFileTests
         Assert.Equal(40, page.LineBlocks.Count);
     }
 
+    /// <summary>
+    /// Locates a DOCX fixture under tests/Issue_Files/docx by walking up from the test output directory.
+    /// </summary>
     private static string FindIssueDocx(string fileName)
     {
         var directory = new DirectoryInfo(AppContext.BaseDirectory);


### PR DESCRIPTION
## Problem

`tests/Issue_Files/docx/Fabrikam.docx` (business-card sheet) rendered as plain text on a white page. Word and LibreOffice both draw a light-blue page background, twenty white rectangles and ten card outlines. All of that comes from one `behindDoc="1"` `wpg:wgp` group with 31 `wps:wsp` children.

## Root cause

`DocxReader` only calls `ReadAnchorShapes` when the run contains no `w:txbxContent`. The first rectangle of this group carries a `wps:txbx` holding a single soft hyphen (and the VML fallback mirrors it with `v:textbox`), so the whole group was skipped. The floating text box path deliberately skips fill extraction for groups (`anchorHasGroupShape`) and expects `ReadAnchorShapes` to draw them, so neither path painted the group.

Falsification check before editing: removing both the `wps:txbx` and the `mc:Fallback` from a copy of the fixture made the existing code emit 21 rectangles and 40 outline segments with the correct geometry; removing only the fallback still produced nothing.

LibreOffice keeps such groups intact: `oox/source/shape/WpgContext.cxx` (`WpgContext::onCreateContext`) creates a shape context for every `wsp` child and recurses into nested `grpSp`; `oox/source/shape/WpsContext.cxx` (`XML_txbx`) only marks that child as a text box; `sw/source/writerfilter/dmapper/GraphicImport.cxx` (`LN_CT_Anchor_behindDoc`) places the anchor behind text.

## Change

When the run contains text box content but the drawing's `wp:anchor` directly holds `wpg:wgp`, still read the group shapes through `ReadAnchorShapes`. `ReadImage` keeps the original guard, and single-shape text boxes keep their existing fill handling.

## Tests and validation

- New test `DocxIssueFileTests.Fabrikam_BehindDocGroupWithTextBox_RendersGroupFills` (fails before the change, passes after).
- `dotnet test tests/MiniPdf.Tests --configuration Release`: 193 passed, 0 failed.
- `git diff --check`: clean.

## Benchmark evidence (.NET, issue suite, docx, Microsoft 365 reference)

Focused run: `pwsh -File scripts/Run-DotNet-VisualBenchmark.ps1 -Suite issue -Format docx -Filter "Fabrikam"`
Full run: `pwsh -File scripts/Run-DotNet-VisualBenchmark.ps1 -Suite issue -Format docx`

| Case | Overall before | Overall after | Visual before | Visual after | Pages (MiniPdf/Ref) |
|---|---|---|---|---|---|
| Fabrikam | 0.6223 | 0.9770 | 0.0558 | 0.9426 | 1/1 (unchanged) |
| issue/docx average (27 cases) | 0.9231 | 0.9363 | | | |

All 27 cases converted, all PDFs valid, all comparison images present, no page-count changes, no `visual_avg` decrease. 25 cases have identical scores. OSCAR WARD moved +0.0033 visual; a rebuild from `main` produces a byte-identical PDF for that case, so the delta comes from the Office cloud-font cache (Source Sans Pro) populated while Word generated the reference PDFs, not from this change.

## Compatibility and scope

Internal `DocxReader` change only; no public API change. Only DOCX documents with a behindDoc `wpg:wgp` group whose child shape carries a text box are affected. Among the repository's docx fixtures, only Fabrikam has that structure. No new third-party material, fixtures or fonts. No documentation change needed.

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DOCX rendering when multiple drawings appear in the same text run.
  * Improved handling of grouped shapes anchored within drawings, preserving child fills and visual details.
  * Improved rendering of grouped shapes in documents containing text boxes, including background fills, rectangles, and lines behind document content.

* **Tests**
  * Added coverage for multiple top-level drawings and grouped shape fills in DOCX documents.
  * Added a rendering test for affected DOCX content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->