### PR TITLE
Add MiniPdf.ClearRegisteredFonts

### DIFF
--- a/documents/README.nuget.md
+++ b/documents/README.nuget.md
@@ -91,6 +91,9 @@ MiniPdf.RegisterFont("NotoSansSC", File.ReadAllBytes("Fonts/NotoSansSC-Regular.t
 MiniPdf.ConvertToPdf("report.docx", "report.pdf");
 ```
 
+Registrations are process-wide. `MiniPdf.ClearRegisteredFonts()` removes them when
+the same process needs a different font set for a later conversion.
+
 ## Command Line
 
 Install the .NET global tool:

--- a/src/MiniPdf/MiniPdf.cs
+++ b/src/MiniPdf/MiniPdf.cs
@@ -129,6 +129,16 @@ public static class MiniPdf
     }
 
     /// <summary>
+    /// Removes all fonts registered with <see cref="RegisterFont"/>.
+    /// Registrations are process-wide; clear them before registering a different font set.
+    /// </summary>
+    public static void ClearRegisteredFonts()
+    {
+        lock (_registeredFonts)
+            _registeredFonts.Clear();
+    }
+
+    /// <summary>
     /// Returns a snapshot of all registered fonts.
     /// </summary>
     internal static List<(string Name, byte[] Data)> GetRegisteredFonts()

--- a/tests/MiniPdf.Tests/RegisteredFontTests.cs
+++ b/tests/MiniPdf.Tests/RegisteredFontTests.cs
@@ -1,0 +1,64 @@
+namespace MiniSoftware.Tests;
+
+/// <summary>
+/// Runs registered-font tests apart from other collections. Registrations are process-wide,
+/// so conversions running in parallel would otherwise read the fonts these tests register.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public class RegisteredFontCollection
+{
+    public const string Name = "Registered fonts";
+}
+
+[Collection(RegisteredFontCollection.Name)]
+public class RegisteredFontTests : IDisposable
+{
+    public RegisteredFontTests() => MiniPdf.ClearRegisteredFonts();
+
+    public void Dispose() => MiniPdf.ClearRegisteredFonts();
+
+    /// <summary>
+    /// Clearing removes every registration, including repeated registrations of the same name.
+    /// </summary>
+    [Fact]
+    public void ClearRegisteredFonts_RemovesAllRegistrations()
+    {
+        MiniPdf.RegisterFont("First", new byte[] { 1 });
+        MiniPdf.RegisterFont("Second", new byte[] { 2 });
+        MiniPdf.RegisterFont("First", new byte[] { 3 });
+        Assert.Equal(3, MiniPdf.GetRegisteredFonts().Count);
+
+        MiniPdf.ClearRegisteredFonts();
+
+        Assert.Empty(MiniPdf.GetRegisteredFonts());
+    }
+
+    /// <summary>
+    /// A host can swap font sets between conversions by clearing and registering again.
+    /// </summary>
+    [Fact]
+    public void ClearRegisteredFonts_AllowsRegisteringADifferentFontSet()
+    {
+        MiniPdf.RegisterFont("NotoSansTC", new byte[] { 1 });
+
+        MiniPdf.ClearRegisteredFonts();
+        MiniPdf.RegisterFont("NotoSansJP", new byte[] { 2 });
+
+        var registered = Assert.Single(MiniPdf.GetRegisteredFonts());
+        Assert.Equal("NotoSansJP", registered.Name);
+    }
+
+    /// <summary>
+    /// A snapshot taken before clearing, such as the one a conversion in progress reads, is not changed.
+    /// </summary>
+    [Fact]
+    public void ClearRegisteredFonts_DoesNotChangeEarlierSnapshot()
+    {
+        MiniPdf.RegisterFont("NotoSansTC", new byte[] { 1 });
+        var snapshot = MiniPdf.GetRegisteredFonts();
+
+        MiniPdf.ClearRegisteredFonts();
+
+        Assert.Equal("NotoSansTC", Assert.Single(snapshot).Name);
+    }
+}

--- a/tests/MiniPdf.Tests/RegisteredFontTests.cs
+++ b/tests/MiniPdf.Tests/RegisteredFontTests.cs
@@ -13,8 +13,14 @@ public class RegisteredFontCollection
 [Collection(RegisteredFontCollection.Name)]
 public class RegisteredFontTests : IDisposable
 {
+    /// <summary>
+    /// Starts each test with no registered fonts.
+    /// </summary>
     public RegisteredFontTests() => MiniPdf.ClearRegisteredFonts();
 
+    /// <summary>
+    /// Clears the fonts a test registered so the next test starts from an empty list.
+    /// </summary>
     public void Dispose() => MiniPdf.ClearRegisteredFonts();
 
     /// <summary>


### PR DESCRIPTION
## Summary

Adds `MiniPdf.ClearRegisteredFonts()` to the .NET library. `RegisterFont` appends to a
process-wide list and there was no way to remove entries, so a long-running host (a server,
or a Blazor WebAssembly app) could not release registrations or swap font sets between
conversions.

The new method clears the list under the existing lock. It matches the Java port's
`clearRegisteredFonts()` and leaves `RegisterFont` behavior unchanged, as agreed in #163
(option 1, without `UnregisterFont`).

Closes #163

Public API: one new public static method. The change is additive.

A conversion already in progress keeps the font snapshot it has read. `PdfWriter` reads
the list separately for embedding (`PdfWriter.cs:173`) and for missing-font diagnostics
(`PdfWriter.cs:2774`), so clearing between those two reads can make the diagnostics
disagree with the embedded fonts; this PR does not change that.

`RegisteredFontTests` runs in a collection with `DisableParallelization = true`, because
registrations are process-wide and conversions in other collections would otherwise read
the fonts the tests register.

`documents/README.nuget.md` gains one sentence under Custom Fonts. The English `README.md`
does not document .NET font registration, so no translated README changes.

## Validation

macOS arm64, .NET SDK 9.0.317, based on `54f06487`.

- `dotnet build src/MiniPdf/MiniPdf.csproj -c Release -f net9.0`: 0 errors, 153 warnings,
  the same count as `54f06487` without this change. `-f netstandard2.0`, `-f net6.0`, and
  `-f net8.0` also build with 0 errors and no warnings on the changed lines. `net462` was
  not built because it does not restore on macOS.
- `dotnet test tests/MiniPdf.Tests -c Release`: 195 passed, 2 failed, 197 total. The three
  new `RegisteredFontTests` pass.
- The two failures, `Issue79_EmbeddedCjkFonts_ProducesCompactPdf(Issue79_FilledContract.docx)`
  and `Issue78_HeaderTable_UsesPreferredFontWidthsForAlignment`, fail the same way on
  `54f06487` without this change on this machine (192 passed, 2 failed, 194 total). CI
  passed on that commit, so they appear to depend on the fonts installed on the host.
- `git diff --check`: clean.

No rendering change, so no visual benchmark was run.

## Checklist

- [x] The change is focused and does not include unrelated formatting or generated files.
- [x] New or changed behavior has automated test coverage where practical.
- [x] Relevant .NET and/or Rust checks pass.
- [x] Public API and compatibility effects are documented.
- [x] Security implications and untrusted-input behavior were considered.
- [x] I have the right to submit every added source file, fixture, font, image, and other asset under its stated license.
- [x] Third-party and generated material includes its source and license.
- [x] Test documents contain no confidential information or personal data.
- [x] User-facing documentation is updated, including translated README files when the English README changed.
- [x] Large benchmark outputs are attached or stored as CI artifacts unless they are required canonical evidence.

Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ClearRegisteredFonts()` to remove all process-wide registered fonts.
  * Applications can now clear and register a different font set between conversions.

* **Documentation**
  * Clarified that font registrations are process-wide.
  * Documented how to clear registered fonts when switching font sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->